### PR TITLE
fix: some errors in the Package.swift

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,6 +1,4 @@
-// Package.swift
-
-// swift-tools-version: 6.1
+// swift-tools-version: 5.3
 import PackageDescription
 
 let package = Package(
@@ -16,7 +14,7 @@ let package = Package(
         ),
         .library(
             name: "plist",
-            targets: ["plist"],
+            targets: ["plist"]
         ),
     ],
     targets: [


### PR DESCRIPTION
`// swift-tools-version:` should be at the top of the file to be recognized
changed the tools version to be lower than 6, many people don't use swift 6
theres an extra trailing `,` which prevented building