### PR TITLE
fix: allow uploads to appstore connect

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,9 +54,9 @@ x86_64_mac_out := "build/x86_64_mac"
 plist_xcframework: plist_clean build_plist_ios build_plist_sim build_plist_x86_64_sim build_plist_mac build_plist_x86_64_mac plist_merge_archs
     rm -rf {{lib_name}}.xcframework
     xcodebuild -create-xcframework \
-        -library {{ios_out}}/lib/libplist-2.0.4.dylib -headers {{ios_out}}/include \
-        -library build/universal-sim/libplist-2.0.4.dylib -headers {{sim_out}}/include \
-        -library build/universal-mac/libplist-2.0.4.dylib -headers {{mac_out}}/include \
+        -framework {{ios_out}}/plist.framework \
+        -framework build/universal-sim/plist.framework \
+        -framework build/universal-mac/plist.framework \
         -output swift/{{lib_name}}.xcframework
 
 plist_clean:
@@ -71,12 +71,26 @@ plist_merge_archs:
         {{x86_64_sim_out}}/lib/libplist-2.0.4.dylib \
         -output build/universal-sim/libplist-2.0.4.dylib
 
+    mkdir -p build/universal-sim/plist.framework/Headers
+    mkdir -p build/universal-sim/plist.framework/Modules
+    cp build/universal-sim/libplist-2.0.4.dylib build/universal-sim/plist.framework/plist
+    cp {{sim_out}}/include/plist/*.h build/universal-sim/plist.framework/Headers
+    cp swift/Info.plist build/universal-sim/plist.framework/Info.plist
+    cp swift/plistinclude/module.modulemap build/universal-sim/plist.framework/Modules/module.modulemap
+
     # Merge macOS dylibs (arm64 + x86_64)
     mkdir -p build/universal-mac
     lipo -create \
         {{mac_out}}/lib/libplist-2.0.4.dylib \
         {{x86_64_mac_out}}/lib/libplist-2.0.4.dylib \
         -output build/universal-mac/libplist-2.0.4.dylib
+
+    mkdir -p build/universal-mac/plist.framework/Headers
+    mkdir -p build/universal-mac/plist.framework/Modules
+    cp build/universal-mac/libplist-2.0.4.dylib build/universal-mac/plist.framework/plist
+    cp {{mac_out}}/include/plist/*.h build/universal-mac/plist.framework/Headers
+    cp swift/Info.plist build/universal-mac/plist.framework/Info.plist
+    cp swift/plistinclude/module.modulemap build/universal-mac/plist.framework/Modules/module.modulemap
 
 build_plist_ios:
     rm -rf {{ios_out}} build/build-ios
@@ -89,14 +103,20 @@ build_plist_ios:
       --without-cython \
       --without-tools \
     CC="$(xcrun --sdk iphoneos --find clang)" \
-    CFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphoneos --show-sdk-path)" \
+    CFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphoneos --show-sdk-path) -mios-version-min=12.0" \
     CXX="$(xcrun --sdk iphoneos --find clang++)" \
-    CXXFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphoneos --show-sdk-path)" \
-    LDFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphoneos --show-sdk-path)" && \
+    CXXFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphoneos --show-sdk-path) -mios-version-min=12.0" \
+    LDFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphoneos --show-sdk-path) -mios-version-min=12.0" && \
       make clean && make -j$(sysctl -n hw.ncpu) && make install
 
-    install_name_tool -id @rpath/libplist-2.0.4.dylib {{ios_out}}/lib/libplist-2.0.4.dylib
+    install_name_tool -id @rpath/plist.framework/plist {{ios_out}}/lib/libplist-2.0.4.dylib
 
+    mkdir -p {{ios_out}}/plist.framework/Headers
+    mkdir -p {{ios_out}}/plist.framework/Modules
+    cp {{ios_out}}/lib/libplist-2.0.4.dylib {{ios_out}}/plist.framework/plist
+    cp {{ios_out}}/include/plist/*.h {{ios_out}}/plist.framework/Headers
+    cp swift/Info.plist {{ios_out}}/plist.framework/Info.plist
+    cp swift/plistinclude/module.modulemap {{ios_out}}/plist.framework/Modules/module.modulemap
 
 build_plist_sim:
     rm -rf {{sim_out}} build/build-sim
@@ -108,13 +128,13 @@ build_plist_sim:
       --without-cython \
       --without-tools \
     CC="$(xcrun --sdk iphonesimulator --find clang)" \
-    CFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)" \
+    CFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -mios-simulator-version-min=12.0" \
     CXX="$(xcrun --sdk iphonesimulator --find clang++)" \
-    CXXFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)" \
-    LDFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)" && \
+    CXXFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -mios-simulator-version-min=12.0" \
+    LDFLAGS="-arch arm64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -mios-simulator-version-min=12.0" && \
       make clean && make -j$(sysctl -n hw.ncpu) && make install
 
-    install_name_tool -id @rpath/libplist-2.0.4.dylib {{sim_out}}/lib/libplist-2.0.4.dylib
+    install_name_tool -id @rpath/plist.framework/plist {{sim_out}}/lib/libplist-2.0.4.dylib
 
 build_plist_x86_64_sim:
     rm -rf {{x86_64_sim_out}} build/build-sim
@@ -126,13 +146,13 @@ build_plist_x86_64_sim:
       --without-cython \
       --without-tools \
     CC="$(xcrun --sdk iphonesimulator --find clang)" \
-    CFLAGS="-arch x86_64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)" \
+    CFLAGS="-arch x86_64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -mios-simulator-version-min=12.0" \
     CXX="$(xcrun --sdk iphonesimulator --find clang++)" \
-    CXXFLAGS="-arch x86_64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)" \
-    LDFLAGS="-arch x86_64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)" && \
+    CXXFLAGS="-arch x86_64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -mios-simulator-version-min=12.0" \
+    LDFLAGS="-arch x86_64 -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -mios-simulator-version-min=12.0" && \
       make clean && make -j$(sysctl -n hw.ncpu) && make install
 
-    install_name_tool -id @rpath/libplist-2.0.4.dylib {{x86_64_sim_out}}/lib/libplist-2.0.4.dylib
+    install_name_tool -id @rpath/plist.framework/plist {{x86_64_sim_out}}/lib/libplist-2.0.4.dylib
 
 build_plist_mac:
     rm -rf {{mac_out}} build/build-mac
@@ -144,13 +164,13 @@ build_plist_mac:
       --without-cython \
       --without-tools \
     CC="$(xcrun --sdk macosx --find clang)" \
-    CFLAGS="-arch arm64 -isysroot $(xcrun --sdk macosx --show-sdk-path)" \
+    CFLAGS="-arch arm64 -isysroot $(xcrun --sdk macosx --show-sdk-path) -mmacosx-version-min=11.0" \
     CXX="$(xcrun --sdk macosx --find clang++)" \
-    CXXFLAGS="-arch arm64 -isysroot $(xcrun --sdk macosx --show-sdk-path)" \
-    LDFLAGS="-arch arm64 -isysroot $(xcrun --sdk macosx --show-sdk-path)" && \
+    CXXFLAGS="-arch arm64 -isysroot $(xcrun --sdk macosx --show-sdk-path) -mmacosx-version-min=11.0" \
+    LDFLAGS="-arch arm64 -isysroot $(xcrun --sdk macosx --show-sdk-path) -mmacosx-version-min=11.0" && \
       make clean && make -j$(sysctl -n hw.ncpu) && make install
 
-    install_name_tool -id @rpath/libplist-2.0.4.dylib {{mac_out}}/lib/libplist-2.0.4.dylib
+    install_name_tool -id @rpath/plist.framework/plist {{mac_out}}/lib/libplist-2.0.4.dylib
 
 build_plist_x86_64_mac:
     rm -rf {{x86_64_mac_out}} build/build-mac
@@ -162,10 +182,10 @@ build_plist_x86_64_mac:
       --without-cython \
       --without-tools \
     CC="$(xcrun --sdk macosx --find clang)" \
-    CFLAGS="-arch x86_64 -isysroot $(xcrun --sdk macosx --show-sdk-path)" \
+    CFLAGS="-arch x86_64 -isysroot $(xcrun --sdk macosx --show-sdk-path) -mmacosx-version-min=11.0" \
     CXX="$(xcrun --sdk macosx --find clang++)" \
-    CXXFLAGS="-arch x86_64 -isysroot $(xcrun --sdk macosx --show-sdk-path)" \
-    LDFLAGS="-arch x86_64 -isysroot $(xcrun --sdk macosx --show-sdk-path)" && \
+    CXXFLAGS="-arch x86_64 -isysroot $(xcrun --sdk macosx --show-sdk-path) -mmacosx-version-min=11.0" \
+    LDFLAGS="-arch x86_64 -isysroot $(xcrun --sdk macosx --show-sdk-path) -mmacosx-version-min=11.0" && \
       make clean && make -j$(sysctl -n hw.ncpu) && make install
 
-    install_name_tool -id @rpath/libplist-2.0.4.dylib {{x86_64_mac_out}}/lib/libplist-2.0.4.dylib
+    install_name_tool -id @rpath/plist.framework/plist {{x86_64_mac_out}}/lib/libplist-2.0.4.dylib

--- a/swift/Info.plist
+++ b/swift/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>plist</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.github.jkcoxson.plist</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>plist</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.7.0</string>
+	<key>MinimumOSVersion</key>
+	<string>12.0</string>
+	<key>CFBundleVersion</key>
+	<string>2.7.0</string>
+</dict>
+</plist>

--- a/swift/plistinclude/module.modulemap
+++ b/swift/plistinclude/module.modulemap
@@ -1,0 +1,6 @@
+framework module plist {
+  umbrella header "plist.h"
+
+  export *
+  module * { export * }
+}


### PR DESCRIPTION
appstore connect requires that libplist is contained in a framework, and not a dylib.

the filestructure may be not up to your standards, so please tell me what to change if necessary.