### PR TITLE
fix: compiling with obfuscate flag

### DIFF
--- a/idevice/src/util.rs
+++ b/idevice/src/util.rs
@@ -130,13 +130,11 @@ fn print_plist(p: &Value, indentation: usize) -> String {
 #[macro_export]
 macro_rules! obf {
     ($lit:literal) => {{
-        #[cfg(feature = "obfuscate")]
-        {
+        #[cfg(feature = "obfuscate")] {
             std::borrow::Cow::Owned(obfstr::obfstr!($lit).to_string())
         }
-        #[cfg(not(feature = "obfuscate"))]
-        {
-            $lit
+        #[cfg(not(feature = "obfuscate"))] {
+            std::borrow::Cow::Borrowed($lit)
         }
     }};
 }


### PR DESCRIPTION
<img width="2054" height="712" alt="image" src="https://github.com/user-attachments/assets/4877d5db-49ee-4e50-957d-2da865d6f793" />

seems like I couldn't compile before, but this fix should make it compile again by adding `std::borrow::Cow::Borrowed()`, should hopefuly conform to `'static, str` properly