### PR TITLE
Fix misagent incorrect status value

### DIFF
--- a/idevice/src/services/misagent.rs
+++ b/idevice/src/services/misagent.rs
@@ -105,7 +105,7 @@ impl MisagentClient {
         match res.remove("Status") {
             Some(plist::Value::Integer(status)) => {
                 if let Some(status) = status.as_unsigned() {
-                    if status == 1 {
+                    if status == 0 {
                         Ok(())
                     } else {
                         Err(IdeviceError::MisagentFailure)
@@ -155,7 +155,7 @@ impl MisagentClient {
         match res.remove("Status") {
             Some(plist::Value::Integer(status)) => {
                 if let Some(status) = status.as_unsigned() {
-                    if status == 1 {
+                    if status == 0 {
                         Ok(())
                     } else {
                         Err(IdeviceError::MisagentFailure)


### PR DESCRIPTION
fix misagent returning error when its a success. 

misagent returns `0` for Success, not `1` as is in the code rn.