### PR TITLE
fix offline build

### DIFF
--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -35,14 +35,22 @@ fn main() {
         .expect("Unable to generate bindings")
         .write_to_file("idevice.h");
 
-    // download plist.h
-    let h = ureq::get("https://raw.githubusercontent.com/libimobiledevice/libplist/refs/heads/master/include/plist/plist.h")
-        .call()
-        .expect("failed to download plist.h");
-    let h = h
-        .into_body()
-        .read_to_string()
-        .expect("failed to get string content");
+    // Check if plist.h exists locally first, otherwise download
+    let plist_h_path = "plist.h";
+    let h = if std::path::Path::new(plist_h_path).exists() {
+        std::fs::read_to_string(plist_h_path)
+            .expect("failed to read plist.h")
+    } else {
+        // download plist.h
+        let h = ureq::get("https://raw.githubusercontent.com/libimobiledevice/libplist/refs/heads/master/include/plist/plist.h")
+            .call()
+            .expect("failed to download plist.h");
+        h
+            .into_body()
+            .read_to_string()
+            .expect("failed to get string content")
+    };
+    
     let mut f = OpenOptions::new().append(true).open("idevice.h").unwrap();
     f.write_all(b"\n\n\n").unwrap();
     f.write_all(&h.into_bytes())


### PR DESCRIPTION
Flathub requires build to be offline  once every dep is declared in config (manifest) file, so fetch inside ffi/build.rs fails

and this PR fixes it by first checking if the file exists locally if not it downloads the header file

With these changes i was able to compile (offline) just fine by populating header file before the build  

`wget -O idevice-rs/ffi/plist.h "https://raw.githubusercontent.com/libimobiledevice/libplist/refs/heads/master/include/plist/plist.h"
`

`cargo build --offline --release --all-features --manifest-path idevice-rs/Cargo.toml`

I am still learning rust, let me know if anything looks off.