### PR TITLE
Fix failure to compile to 32-bit

### DIFF
--- a/idevice/src/services/afc/inner_file.rs
+++ b/idevice/src/services/afc/inner_file.rs
@@ -146,7 +146,7 @@ impl InnerFileDescriptor<'_> {
         let mut collected_bytes = Vec::with_capacity(n);
 
         for chunk in chunk_number(n, MAX_TRANSFER as usize) {
-            let header_payload = [self.fd.to_le_bytes(), chunk.to_le_bytes()].concat();
+            let header_payload = [self.fd.to_le_bytes(), (chunk as u64).to_le_bytes()].concat();
             let res = self
                 .as_mut()
                 .send_packet(AfcOpcode::Read, header_payload, Vec::new())


### PR DESCRIPTION
It fails to compile on 32-bit targets.

This is what happens when I build on x86_64 EndeavourOS with version [0.1.50](https://github.com/jkcoxson/idevice/commit/a708db630740e4870396b33827bb2222a839fa87)
```
❯ cargo build --target i686-unknown-linux-gnu

   Compiling idevice v0.1.50 (/home/tom/Desktop/Projects/idevice/idevice)
warning: unused import: `error`
  --> idevice/src/lib.rs:41:22
   |
41 | use tracing::{debug, error, trace};
   |                      ^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

error[E0308]: mismatched types
   --> idevice/src/services/afc/inner_file.rs:149:58
    |
149 |             let header_payload = [self.fd.to_le_bytes(), chunk.to_le_bytes()].concat();
    |                                                          ^^^^^^^^^^^^^^^^^^^ expected an array with a size of 8, found one with a size of 4

For more information about this error, try `rustc --explain E0308`.
warning: `idevice` (lib) generated 1 warning
error: could not compile `idevice` (lib) due to 1 previous error; 1 warning emitted
```

Applying this change seems to resolve the issue although am not too sure on whether or not this is correct.