### PR TITLE
chore: gate readme docs include

### DIFF
--- a/idevice/Cargo.toml
+++ b/idevice/Cargo.toml
@@ -213,3 +213,4 @@ full = [
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/idevice/src/lib.rs
+++ b/idevice/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]
 // Jackson Coxson


### PR DESCRIPTION
 This avoids extra rustdoc only file requirement for vendored offline builds, such as Flathub packages.