### PR TITLE
fix: add missing sha2 and rsa deps to remote_pairing feature

### DIFF
--- a/idevice/Cargo.toml
+++ b/idevice/Cargo.toml
@@ -209,6 +209,8 @@ remote_pairing = [
   "dep:cbc",
   "dep:hmac",
   "dep:sha1",
+  "dep:sha2",
+  "dep:rsa",
 ]
 restore_service = []
 rsd = ["xpc"]


### PR DESCRIPTION
The `remote_pairing` feature uses `sha2` and `rsa` but didn't declare them as feature dependencies. This causes compilation failures when enabling `remote_pairing` without another feature that pulls them in.

  ### `sha2`
  - `mod.rs` — `Sha512` for HKDF key derivation and SRP client
  - `tls_psk.rs` — `Sha256`/`Sha384` for HMAC and transcript hashing

  ### `rsa`
  - `mod.rs` — `SignerMut` for signing during pairing
  - `rp_pairing_file.rs` — `OsRng` for random value generation