### PR TITLE
fix: feature gating for error conversions and dead deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,6 @@ dependencies = [
  "async-stream",
  "async_zip",
  "base64 0.22.1",
- "byteorder",
  "bytes",
  "cbc",
  "chacha20poly1305",
@@ -1367,7 +1366,6 @@ dependencies = [
  "idevice-srp",
  "indexmap",
  "jktcp",
- "json",
  "libc",
  "ns-keyed-archive",
  "obfstr",
@@ -1578,12 +1576,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"

--- a/idevice/Cargo.toml
+++ b/idevice/Cargo.toml
@@ -37,8 +37,6 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
 ] }
 
 serde_json = { version = "1", optional = true }
-json = { version = "0.12", optional = true }
-byteorder = { version = "1.5", optional = true }
 bytes = { version = "1.10", optional = true }
 
 reqwest = { version = "0.13", features = [
@@ -119,17 +117,21 @@ aws-lc = ["rustls", "rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 ring = ["rustls", "rustls/ring", "tokio-rustls/ring"]
 rustls = ["dep:rustls", "dep:tokio-rustls"]
 openssl = ["dep:openssl", "dep:tokio-openssl"]
+# Internal features: gate error‐conversion impls so every feature that pulls
+# in the dep automatically gets `From<…> for IdeviceError`.
+_serde_json = ["dep:serde_json"]
+_reqwest = ["dep:reqwest"]
 
 afc = ["dep:chrono", "dep:futures"]
 amfi = []
 bt_packet_logger = []
 companion_proxy = []
 core_device = ["xpc", "dep:uuid", "dep:ns-keyed-archive"]
-core_device_proxy = ["dep:serde_json", "dep:json", "dep:byteorder"]
+core_device_proxy = ["_serde_json"]
 crashreportcopymobile = ["afc"]
 debug_proxy = []
 diagnostics_relay = []
-dvt = ["dep:byteorder", "dep:ns-keyed-archive"]
+dvt = ["dep:ns-keyed-archive"]
 energy_monitor = ["dvt"]
 graphics = ["dvt", "rsd"]
 device_info = ["dvt"]
@@ -159,9 +161,9 @@ xctest = [
 springboardservices = []
 misagent = []
 mobile_image_mounter = ["dep:sha2"]
-mobileactivationd = ["dep:reqwest"]
+mobileactivationd = ["_reqwest"]
 mobilebackup2 = []
-wda = ["dep:serde_json", "tokio/time", "tokio/net"]
+wda = ["_serde_json", "tokio/time", "tokio/net"]
 notification_proxy = [
   "tokio/macros",
   "tokio/time",
@@ -196,8 +198,8 @@ wasm = [
   "wasm-crypto",
 ]
 remote_pairing = [
-  "dep:serde_json",
-  "dep:json",
+  "_serde_json",
+  "xpc",
   "dep:x25519-dalek",
   "dep:ed25519-dalek",
   "dep:hkdf",
@@ -222,8 +224,8 @@ tunnel_tcp_stack = ["dep:jktcp"]
 # `tokio/fs`, which doesn't compile on wasm32, so it is opt-in rather than
 # implied by `tunnel_tcp_stack`.
 tunnel_tcp_stack_pcap = ["tunnel_tcp_stack", "jktcp/pcap"]
-tss = ["dep:uuid", "dep:reqwest"]
-tunneld = ["dep:serde_json", "dep:json", "dep:reqwest"]
+tss = ["dep:uuid", "_reqwest"]
+tunneld = ["_serde_json", "_reqwest"]
 usbmuxd = ["tokio/net", "dep:futures"]
 xpc = ["dep:indexmap", "dep:uuid", "dep:async-stream", "dep:futures"]
 full = [

--- a/idevice/src/lib.rs
+++ b/idevice/src/lib.rs
@@ -791,7 +791,7 @@ pub enum IdeviceError {
     Utf8(#[from] std::string::FromUtf8Error),
     #[error("failed to parse bytes as valid utf8")]
     Utf8Error,
-    #[cfg(feature = "core_device_proxy")]
+    #[cfg(feature = "_serde_json")]
     #[error("JSON serialization failed")]
     Json(#[from] serde_json::Error),
     #[error("cannot parse string as IpAddr")]
@@ -800,7 +800,7 @@ pub enum IdeviceError {
     NotEnoughBytes(usize, usize),
     #[error("integer overflow")]
     IntegerOverflow,
-    #[cfg(any(feature = "tss", feature = "tunneld"))]
+    #[cfg(feature = "_reqwest")]
     #[error("http reqwest error")]
     Reqwest(#[from] reqwest::Error),
 
@@ -995,12 +995,12 @@ impl IdeviceError {
             IdeviceError::Plist(_) => 5,
             IdeviceError::Utf8(_) => 6,
             IdeviceError::Utf8Error => 7,
-            #[cfg(feature = "core_device_proxy")]
+            #[cfg(feature = "_serde_json")]
             IdeviceError::Json(_) => 8,
             IdeviceError::AddrParseError(_) => 9,
             IdeviceError::NotEnoughBytes(_, _) => 10,
             IdeviceError::IntegerOverflow => 11,
-            #[cfg(any(feature = "tss", feature = "tunneld"))]
+            #[cfg(feature = "_reqwest")]
             IdeviceError::Reqwest(_) => 12,
 
             // 13: Protocol/device response

--- a/idevice/src/remote_pairing/tunnel.rs
+++ b/idevice/src/remote_pairing/tunnel.rs
@@ -33,8 +33,7 @@ pub async fn connect_tls_psk_tunnel_native(
         "type": "clientHandshakeRequest",
         "mtu": DEFAULT_MTU
     });
-    let body =
-        serde_json::to_vec(&request).map_err(|e| IdeviceError::InternalError(e.to_string()))?;
+    let body = serde_json::to_vec(&request)?;
 
     let mut pkt = Vec::new();
     pkt.extend_from_slice(CDTUNNEL_MAGIC);

--- a/idevice/src/tunnel.rs
+++ b/idevice/src/tunnel.rs
@@ -49,8 +49,7 @@ impl<R: ReadWrite> CdTunnel<R> {
             "type": "clientHandshakeRequest",
             "mtu": DEFAULT_MTU
         });
-        let body =
-            serde_json::to_vec(&request).map_err(|e| IdeviceError::InternalError(e.to_string()))?;
+        let body = serde_json::to_vec(&request)?;
 
         stream.write_all(CDTUNNEL_MAGIC).await?;
         stream.write_all(&(body.len() as u16).to_be_bytes()).await?;
@@ -74,8 +73,7 @@ impl<R: ReadWrite> CdTunnel<R> {
         let mut response_buf = vec![0u8; response_len];
         stream.read_exact(&mut response_buf).await?;
 
-        let response: serde_json::Value = serde_json::from_slice(&response_buf)
-            .map_err(|e| IdeviceError::InternalError(e.to_string()))?;
+        let response: serde_json::Value = serde_json::from_slice(&response_buf)?;
 
         debug!("CDTunnel handshake response: {response:#?}");
 


### PR DESCRIPTION
`From<serde_json::Error> for IdeviceError` was gated behind `#[cfg(feature = "core_device_proxy")]`, but multiple features (`wda`, `remote_pairing`, `tunneld`) also pull in `serde_json` and need that conversion. Compiling `remote_pairing` without `core_device_proxy` would fail. The same bug existed for `reqwest` — `mobileactivationd` depends on it but wasn't listed in the `Reqwest` error variant gate.

Additionally, two optional dependencies (`json` and `byteorder`) were declared and activated by features but never actually imported anywhere in the source code. And `remote_pairing` used `RemoteXpcClient` from the `xpc` module without declaring `xpc` as a dependency.

### Changes

#### Internal feature flags (`Cargo.toml`)

- Added `_serde_json = ["dep:serde_json"]` — all features needing serde_json depend on this instead of `dep:serde_json` directly
- Added `_reqwest = ["dep:reqwest"]` — same pattern for reqwest
- This way, the error `From` impl gate (`#[cfg(feature = "_serde_json")]`) never drifts from which features actually bring in the dep

#### Dead dependency removal (`Cargo.toml`)

- Removed `json` (v0.12) — never imported in source, leftover from before serde_json migration
- Removed `byteorder` (v1.5) — never imported in source, was listed in `core_device_proxy` and `dvt` for no reason

#### Missing dependency (`Cargo.toml`)

- Added `xpc` to `remote_pairing` feature — `remote_pairing/socket.rs` imports `RemoteXpcClient` and `xpc::XPCObject`

#### Error variant gates (`lib.rs`)

- `Json` variant: `#[cfg(feature = "core_device_proxy")]` -> `#[cfg(feature = "_serde_json")]`
- `Reqwest` variant: `#[cfg(any(feature = "tss", feature = "tunneld"))]` -> `#[cfg(feature = "_reqwest")]`
- Updated matching arms in `code()` method accordingly

#### Workaround removal (`tunnel.rs`, `remote_pairing/tunnel.rs`)

- Removed `.map_err(|e| IdeviceError::InternalError(e.to_string()))` on serde_json calls — now that the `From` impl is available, plain `?` works
