### PR TITLE
refactor: remove pairing_file field and state param from RemotePairingClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,6 @@ dependencies = [
  "async-stream",
  "async_zip",
  "base64 0.22.1",
- "byteorder",
  "bytes",
  "cbc",
  "chacha20poly1305",
@@ -1367,7 +1366,6 @@ dependencies = [
  "idevice-srp",
  "indexmap",
  "jktcp",
- "json",
  "libc",
  "ns-keyed-archive",
  "obfstr",
@@ -1578,12 +1576,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -24,6 +24,7 @@ windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock"] }
 [features]
 aws-lc = ["idevice/aws-lc"]
 ring = ["idevice/ring"]
+openssl = ["idevice/openssl"]
 
 
 afc = ["idevice/afc"]

--- a/ffi/src/lockdown.rs
+++ b/ffi/src/lockdown.rs
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn lockdownd_start_session(
     client: *mut LockdowndClientHandle,
     pairing_file: *mut IdevicePairingFile,
 ) -> *mut IdeviceFfiError {
-    let res: Result<(), IdeviceError> = run_sync_local(async move {
+    let res: Result<_, IdeviceError> = run_sync_local(async move {
         let client_ref = unsafe { &mut (*client).0 };
         let pairing_file_ref = unsafe { &(*pairing_file).0 };
 

--- a/ffi/src/tunnel_provider.rs
+++ b/ffi/src/tunnel_provider.rs
@@ -32,7 +32,6 @@ unsafe impl Sync for PinCtx {}
 /// the TLS-PSK tunnel and return adapter + handshake.
 async fn finish_tunnel(
     rpc: &mut idevice::remote_pairing::RemotePairingClient<
-        '_,
         impl idevice::remote_pairing::RpPairingSocketProvider,
     >,
     connect_addr: std::net::SocketAddr,
@@ -184,8 +183,8 @@ pub unsafe extern "C" fn tunnel_pair_usb(
         let _ = conn.recv_root().await?;
 
         let mut rpf = RpPairingFile::generate(&host);
-        let mut rpc = RemotePairingClient::new(conn, &host, &mut rpf);
-        rpc.connect(async |_| get_pin(pin_callback, &ctx), 0u8)
+        let mut rpc = RemotePairingClient::new(conn, &host);
+        rpc.connect(&mut rpf, async || get_pin(pin_callback, &ctx))
             .await?;
 
         Ok::<_, IdeviceError>(rpf)
@@ -261,8 +260,8 @@ pub unsafe extern "C" fn tunnel_create_remotexpc(
         let _ = conn.recv_root().await?;
 
         // RPPairing over RemoteXPC
-        let mut rpc = RemotePairingClient::new(conn, &host, rpf);
-        rpc.connect(async |_| get_pin(pin_callback, &ctx), 0u8)
+        let mut rpc = RemotePairingClient::new(conn, &host);
+        rpc.connect(rpf, async || get_pin(pin_callback, &ctx))
             .await?;
 
         finish_tunnel(&mut rpc, socket_addr).await
@@ -326,8 +325,8 @@ pub unsafe extern "C" fn tunnel_create_rppairing(
             .map_err(|e| IdeviceError::InternalError(format!("connect: {e}")))?;
         let conn = RpPairingSocket::new(stream);
 
-        let mut rpc = RemotePairingClient::new(conn, &host, rpf);
-        rpc.connect(async |_| get_pin(pin_callback, &ctx), 0u8)
+        let mut rpc = RemotePairingClient::new(conn, &host);
+        rpc.connect(rpf, async || get_pin(pin_callback, &ctx))
             .await?;
 
         finish_tunnel(&mut rpc, socket_addr).await

--- a/idevice/Cargo.toml
+++ b/idevice/Cargo.toml
@@ -75,11 +75,10 @@ web-time = { version = "1", optional = true }
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"
 
-# Native-only tokio features: `fs` (used by `utils::installation` helpers) and
-# `rt-multi-thread` (used by AFC's close-on-drop fallback). Both are rejected
-# by tokio on wasm32-unknown-unknown.
+# Native-only tokio feature: `fs` is used by `utils::installation` helpers.
+# Rejected by tokio on wasm32-unknown-unknown.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["fs", "rt-multi-thread"] }
+tokio = { version = "1", features = ["fs"] }
 
 # wasm32-unknown-unknown: forward `js` / `wasm_js` features through to the
 # transitive `getrandom` crates so Web Crypto is used for randomness, and

--- a/idevice/Cargo.toml
+++ b/idevice/Cargo.toml
@@ -37,8 +37,6 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
 ] }
 
 serde_json = { version = "1", optional = true }
-json = { version = "0.12", optional = true }
-byteorder = { version = "1.5", optional = true }
 bytes = { version = "1.10", optional = true }
 
 reqwest = { version = "0.13", features = [
@@ -119,17 +117,21 @@ aws-lc = ["rustls", "rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 ring = ["rustls", "rustls/ring", "tokio-rustls/ring"]
 rustls = ["dep:rustls", "dep:tokio-rustls"]
 openssl = ["dep:openssl", "dep:tokio-openssl"]
+# Internal features: gate error‐conversion impls so every feature that pulls
+# in the dep automatically gets `From<…> for IdeviceError`.
+_serde_json = ["dep:serde_json"]
+_reqwest = ["dep:reqwest"]
 
 afc = ["dep:chrono", "dep:futures"]
 amfi = []
 bt_packet_logger = []
 companion_proxy = []
 core_device = ["xpc", "dep:uuid", "dep:ns-keyed-archive"]
-core_device_proxy = ["dep:serde_json", "dep:json", "dep:byteorder"]
+core_device_proxy = ["_serde_json"]
 crashreportcopymobile = ["afc"]
 debug_proxy = []
 diagnostics_relay = []
-dvt = ["dep:byteorder", "dep:ns-keyed-archive"]
+dvt = ["dep:ns-keyed-archive"]
 energy_monitor = ["dvt"]
 graphics = ["dvt", "rsd"]
 device_info = ["dvt"]
@@ -159,9 +161,9 @@ xctest = [
 springboardservices = []
 misagent = []
 mobile_image_mounter = ["dep:sha2"]
-mobileactivationd = ["dep:reqwest"]
+mobileactivationd = ["_reqwest"]
 mobilebackup2 = []
-wda = ["dep:serde_json", "tokio/time", "tokio/net"]
+wda = ["_serde_json", "tokio/time", "tokio/net"]
 notification_proxy = [
   "tokio/macros",
   "tokio/time",
@@ -196,8 +198,8 @@ wasm = [
   "wasm-crypto",
 ]
 remote_pairing = [
-  "dep:serde_json",
-  "dep:json",
+  "_serde_json",
+  "xpc",
   "dep:x25519-dalek",
   "dep:ed25519-dalek",
   "dep:hkdf",
@@ -222,8 +224,8 @@ tunnel_tcp_stack = ["dep:jktcp"]
 # `tokio/fs`, which doesn't compile on wasm32, so it is opt-in rather than
 # implied by `tunnel_tcp_stack`.
 tunnel_tcp_stack_pcap = ["tunnel_tcp_stack", "jktcp/pcap"]
-tss = ["dep:uuid", "dep:reqwest"]
-tunneld = ["dep:serde_json", "dep:json", "dep:reqwest"]
+tss = ["dep:uuid", "_reqwest"]
+tunneld = ["_serde_json", "_reqwest"]
 usbmuxd = ["tokio/net", "dep:futures"]
 xpc = ["dep:indexmap", "dep:uuid", "dep:async-stream", "dep:futures"]
 full = [

--- a/idevice/src/lib.rs
+++ b/idevice/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(missing_copy_implementations)]
 // Jackson Coxson
 
-#[cfg(all(feature = "pair", feature = "rustls"))]
+#[cfg(feature = "pair")]
 mod ca;
 pub mod cursor;
 mod obfuscation;
@@ -114,22 +114,7 @@ pub trait IdeviceService: Sized {
     async fn connect(provider: &dyn IdeviceProvider) -> Result<Self, IdeviceError> {
         let mut lockdown = LockdownClient::connect(provider).await?;
 
-        #[cfg(feature = "openssl")]
         let legacy = lockdown
-            .get_value(Some("ProductVersion"), None)
-            .await
-            .ok()
-            .as_ref()
-            .and_then(|x| x.as_string())
-            .and_then(|x| x.split(".").next())
-            .and_then(|x| x.parse::<u8>().ok())
-            .map(|x| x < 5)
-            .unwrap_or(false);
-
-        #[cfg(not(feature = "openssl"))]
-        let legacy = false;
-
-        lockdown
             .start_session(&provider.get_pairing_file().await?)
             .await?;
         // Best-effort fetch UDID for downstream defaults (e.g., MobileBackup2 Target/Source identifiers)
@@ -705,7 +690,7 @@ impl Idevice {
                 connector.set_options(openssl::ssl::SslOptions::ALLOW_UNSAFE_LEGACY_RENEGOTIATION);
             }
 
-            let mut connector = connector.build().configure()?.into_ssl("ur mom")?;
+            let mut connector = connector.build().configure()?.into_ssl("Device")?;
 
             connector.set_certificate(&pairing_file.host_certificate)?;
             connector.set_private_key(&pairing_file.host_private_key)?;

--- a/idevice/src/lib.rs
+++ b/idevice/src/lib.rs
@@ -42,25 +42,6 @@ pub(crate) mod time {
     pub use wasmtimer::tokio::*;
 }
 
-/// Spawn a `'static + Send` future on whatever async executor is current.
-/// `tokio::spawn` on native; `wasm_bindgen_futures::spawn_local` on wasm32
-/// (the latter doesn't require Send but accepts Send futures fine). Returns
-/// `()` so callers don't see a JoinHandle — for tasks that need cancellation,
-/// pair the spawn with an explicit `tokio::sync::Notify` / channel signal.
-#[allow(dead_code)]
-pub(crate) fn spawn<F>(fut: F)
-where
-    F: std::future::Future<Output = ()> + Send + 'static,
-{
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        tokio::spawn(fut);
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        wasm_bindgen_futures::spawn_local(fut);
-    }
-}
 #[cfg(any(feature = "core_device_proxy", feature = "remote_pairing"))]
 pub mod tunnel;
 

--- a/idevice/src/lib.rs
+++ b/idevice/src/lib.rs
@@ -791,7 +791,7 @@ pub enum IdeviceError {
     Utf8(#[from] std::string::FromUtf8Error),
     #[error("failed to parse bytes as valid utf8")]
     Utf8Error,
-    #[cfg(feature = "core_device_proxy")]
+    #[cfg(feature = "_serde_json")]
     #[error("JSON serialization failed")]
     Json(#[from] serde_json::Error),
     #[error("cannot parse string as IpAddr")]
@@ -800,7 +800,7 @@ pub enum IdeviceError {
     NotEnoughBytes(usize, usize),
     #[error("integer overflow")]
     IntegerOverflow,
-    #[cfg(any(feature = "tss", feature = "tunneld"))]
+    #[cfg(feature = "_reqwest")]
     #[error("http reqwest error")]
     Reqwest(#[from] reqwest::Error),
 
@@ -995,12 +995,12 @@ impl IdeviceError {
             IdeviceError::Plist(_) => 5,
             IdeviceError::Utf8(_) => 6,
             IdeviceError::Utf8Error => 7,
-            #[cfg(feature = "core_device_proxy")]
+            #[cfg(feature = "_serde_json")]
             IdeviceError::Json(_) => 8,
             IdeviceError::AddrParseError(_) => 9,
             IdeviceError::NotEnoughBytes(_, _) => 10,
             IdeviceError::IntegerOverflow => 11,
-            #[cfg(any(feature = "tss", feature = "tunneld"))]
+            #[cfg(feature = "_reqwest")]
             IdeviceError::Reqwest(_) => 12,
 
             // 13: Protocol/device response

--- a/idevice/src/pairing_file.rs
+++ b/idevice/src/pairing_file.rs
@@ -296,6 +296,7 @@ impl TryFrom<PairingFile> for RawPairingFile {
     }
 }
 
+#[cfg(feature = "rustls")]
 /// Helper function to ensure data has proper PEM headers
 /// If the data already has headers, it returns it as is
 /// If not, it adds the appropriate BEGIN and END headers
@@ -339,6 +340,7 @@ fn ensure_pem_headers(data: &[u8], pem_type: &str) -> Vec<u8> {
     result
 }
 
+#[cfg(feature = "rustls")]
 /// Check if data is already in PEM format
 fn is_pem_formatted(data: &[u8]) -> bool {
     if let Ok(data_str) = std::str::from_utf8(data) {
@@ -348,6 +350,7 @@ fn is_pem_formatted(data: &[u8]) -> bool {
     }
 }
 
+#[cfg(feature = "rustls")]
 /// Check if data is already base64 encoded
 fn is_base64(data: &[u8]) -> bool {
     if let Ok(data_str) = std::str::from_utf8(data) {

--- a/idevice/src/pairing_file.rs
+++ b/idevice/src/pairing_file.rs
@@ -55,7 +55,7 @@ pub struct PairingFile {
     pub root_certificate: X509,
     pub system_buid: String,
     pub host_id: String,
-    pub escrow_bag: Vec<u8>,
+    pub escrow_bag: Option<Vec<u8>>,
     pub wifi_mac_address: String,
     pub udid: Option<String>,
 }

--- a/idevice/src/remote_pairing/mod.rs
+++ b/idevice/src/remote_pairing/mod.rs
@@ -40,11 +40,10 @@ pub use tunnel::{CdTunnel, TunnelInfo, connect_tls_psk_tunnel_native};
 const RPPAIRING_MAGIC: &[u8] = b"RPPairing";
 const WIRE_PROTOCOL_VERSION: u8 = 19;
 
-pub struct RemotePairingClient<'a, R: RpPairingSocketProvider> {
+pub struct RemotePairingClient<R: RpPairingSocketProvider> {
     inner: R,
     sequence_number: usize,
     encrypted_sequence_number: u64,
-    pairing_file: &'a mut RpPairingFile,
     sending_host: String,
 
     /// The shared secret from X25519 (pair-verify) or SRP (initial pairing).
@@ -57,18 +56,17 @@ pub struct RemotePairingClient<'a, R: RpPairingSocketProvider> {
     paired_peer_device: Option<PeerDevice>,
 }
 
-impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
-    pub fn new(inner: R, sending_host: &str, pairing_file: &'a mut RpPairingFile) -> Self {
-        // Initial ciphers derived from Ed25519 key; will be re-derived from
+impl<R: RpPairingSocketProvider> RemotePairingClient<R> {
+    pub fn new(inner: R, sending_host: &str) -> Self {
+        // Initial ciphers are placeholders; they will be re-derived from
         // the actual encryption_key once pair-verify or pairing completes.
-        let initial_key = pairing_file.e_private_key.as_bytes().to_vec();
+        let initial_key = vec![0u8; 32];
         let (client_cipher, server_cipher) = Self::derive_main_ciphers(&initial_key);
 
         Self {
             inner,
             sequence_number: 0,
             encrypted_sequence_number: 0,
-            pairing_file,
             sending_host: sending_host.to_string(),
             encryption_key: initial_key,
             client_cipher,
@@ -97,18 +95,18 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
         &self.encryption_key
     }
 
-    pub async fn connect<Fut, S>(
+    pub async fn connect<Fut>(
         &mut self,
-        pin_callback: impl Fn(S) -> Fut,
-        state: S,
+        pairing_file: &mut RpPairingFile,
+        pin_callback: impl Fn() -> Fut,
     ) -> Result<(), IdeviceError>
     where
         Fut: std::future::Future<Output = String>,
     {
         self.attempt_pair_verify().await?;
 
-        if self.validate_pairing().await.is_err() {
-            self.pair(pin_callback, state).await?;
+        if self.validate_pairing(pairing_file).await.is_err() {
+            self.pair(pairing_file, pin_callback).await?;
         }
         Ok(())
     }
@@ -122,7 +120,10 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
             ))
     }
 
-    pub async fn validate_pairing(&mut self) -> Result<(), IdeviceError> {
+    pub async fn validate_pairing(
+        &mut self,
+        pairing_file: &mut RpPairingFile,
+    ) -> Result<(), IdeviceError> {
         let x_private_key = EphemeralSecret::random_from_rng(OsRng);
         let x_public_key = X25519PublicKey::from(&x_private_key);
 
@@ -204,11 +205,11 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
         // ChaCha20Poly1305 AEAD cipher
         let cipher = ChaCha20Poly1305::new(chacha20poly1305::Key::from_slice(&okm));
 
-        let ed25519_signing_key = &mut self.pairing_file.e_private_key;
+        let ed25519_signing_key = &mut pairing_file.e_private_key;
 
-        let mut signbuf = Vec::with_capacity(32 + self.pairing_file.identifier.len() + 32);
+        let mut signbuf = Vec::with_capacity(32 + pairing_file.identifier.len() + 32);
         signbuf.extend_from_slice(x_public_key.as_bytes()); // 32 bytes
-        signbuf.extend_from_slice(self.pairing_file.identifier.as_bytes()); // variable
+        signbuf.extend_from_slice(pairing_file.identifier.as_bytes()); // variable
         signbuf.extend_from_slice(device_public_key.as_bytes()); // 32 bytes
 
         let signature: Signature = ed25519_signing_key.sign(&signbuf);
@@ -216,7 +217,7 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
         let plaintext = vec![
             tlv::TLV8Entry {
                 tlv_type: tlv::PairingDataComponentType::Identifier,
-                data: self.pairing_file.identifier.as_bytes().to_vec(),
+                data: pairing_file.identifier.as_bytes().to_vec(),
             },
             tlv::TLV8Entry {
                 tlv_type: tlv::PairingDataComponentType::Signature,
@@ -348,30 +349,29 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
         }
     }
 
-    pub async fn pair<Fut, S>(
+    pub async fn pair<Fut>(
         &mut self,
-        pin_callback: impl Fn(S) -> Fut,
-        state: S,
+        pairing_file: &mut RpPairingFile,
+        pin_callback: impl Fn() -> Fut,
     ) -> Result<(), IdeviceError>
     where
         Fut: std::future::Future<Output = String>,
     {
-        let (salt, public_key, pin) = self.request_pair_consent(pin_callback, state).await?;
+        let (salt, public_key, pin) = self.request_pair_consent(pin_callback).await?;
         let key = self.init_srp_context(&salt, &public_key, &pin).await?;
-        let tlv = self.save_pair_record_on_peer(&key).await?;
+        let tlv = self.save_pair_record_on_peer(pairing_file, &key).await?;
         let peer_device = peer_device::parse_peer_device_from_tlv(&tlv)?;
 
-        self.pairing_file.alt_irk = Some(peer_device.alt_irk.clone());
+        pairing_file.alt_irk = Some(peer_device.alt_irk.clone());
         self.paired_peer_device = Some(peer_device);
 
         Ok(())
     }
 
     /// Returns salt and public key and pin
-    async fn request_pair_consent<Fut, S>(
+    async fn request_pair_consent<Fut>(
         &mut self,
-        pin_callback: impl Fn(S) -> Fut,
-        state: S,
+        pin_callback: impl Fn() -> Fut,
     ) -> Result<(Vec<u8>, Vec<u8>, String), IdeviceError>
     where
         Fut: std::future::Future<Output = String>,
@@ -472,7 +472,7 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
 
         let pin = match pin {
             Some(p) => p,
-            None => pin_callback(state).await,
+            None => pin_callback().await,
         };
 
         if salt.is_empty() || public_key.is_empty() {
@@ -583,6 +583,7 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
 
     async fn save_pair_record_on_peer(
         &mut self,
+        pairing_file: &mut RpPairingFile,
         encryption_key: &[u8],
     ) -> Result<Vec<tlv::TLV8Entry>, IdeviceError> {
         let salt = b"Pair-Setup-Encrypt-Salt";
@@ -596,7 +597,7 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
         // Save the SRP session key as the encryption key
         self.encryption_key = encryption_key.to_vec();
 
-        self.pairing_file.recreate_signing_keys();
+        pairing_file.recreate_signing_keys();
         {
             // Re-derive main ciphers from the SRP session key
             let (cc, sc) = Self::derive_main_ciphers(encryption_key);
@@ -606,7 +607,7 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
 
         let hk = Hkdf::<Sha512>::new(Some(b"Pair-Setup-Controller-Sign-Salt"), encryption_key);
 
-        let mut signbuf = Vec::with_capacity(32 + self.pairing_file.identifier.len() + 32);
+        let mut signbuf = Vec::with_capacity(32 + pairing_file.identifier.len() + 32);
 
         let mut hkdf_out = [0u8; 32];
         hk.expand(b"Pair-Setup-Controller-Sign-Info", &mut hkdf_out)
@@ -614,17 +615,17 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
 
         signbuf.extend_from_slice(&hkdf_out);
 
-        signbuf.extend_from_slice(self.pairing_file.identifier.as_bytes());
-        signbuf.extend_from_slice(self.pairing_file.e_public_key.as_bytes());
+        signbuf.extend_from_slice(pairing_file.identifier.as_bytes());
+        signbuf.extend_from_slice(pairing_file.e_public_key.as_bytes());
 
-        let signature = self.pairing_file.e_private_key.sign(&signbuf);
+        let signature = pairing_file.e_private_key.sign(&signbuf);
 
         let device_info = crate::plist!({
             "altIRK": b"\xe9\xe8-\xc0jIykVoT\x00\x19\xb1\xc7{".to_vec(),
             "btAddr": "11:22:33:44:55:66",
             "mac": b"\x11\x22\x33\x44\x55\x66".to_vec(),
             "remotepairing_serial_number": "AAAAAAAAAAAA",
-            "accountID": self.pairing_file.identifier.as_str(),
+            "accountID": pairing_file.identifier.as_str(),
             "model": "computer-model",
             "name": self.sending_host.as_str()
         });
@@ -633,11 +634,11 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
         let tlv = tlv::serialize_tlv8(&[
             tlv::TLV8Entry {
                 tlv_type: tlv::PairingDataComponentType::Identifier,
-                data: self.pairing_file.identifier.as_bytes().to_vec(),
+                data: pairing_file.identifier.as_bytes().to_vec(),
             },
             tlv::TLV8Entry {
                 tlv_type: tlv::PairingDataComponentType::PublicKey,
-                data: self.pairing_file.e_public_key.to_bytes().to_vec(),
+                data: pairing_file.e_public_key.to_bytes().to_vec(),
             },
             tlv::TLV8Entry {
                 tlv_type: tlv::PairingDataComponentType::Signature,
@@ -900,12 +901,11 @@ impl<'a, R: RpPairingSocketProvider> RemotePairingClient<'a, R> {
     }
 }
 
-impl<R: RpPairingSocketProvider> std::fmt::Debug for RemotePairingClient<'_, R> {
+impl<R: RpPairingSocketProvider> std::fmt::Debug for RemotePairingClient<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RemotePairingClient")
             .field("inner", &self.inner)
             .field("sequence_number", &self.sequence_number)
-            .field("pairing_file", &self.pairing_file)
             .field("sending_host", &self.sending_host)
             .finish()
     }

--- a/idevice/src/remote_pairing/tunnel.rs
+++ b/idevice/src/remote_pairing/tunnel.rs
@@ -33,8 +33,7 @@ pub async fn connect_tls_psk_tunnel_native(
         "type": "clientHandshakeRequest",
         "mtu": DEFAULT_MTU
     });
-    let body =
-        serde_json::to_vec(&request).map_err(|e| IdeviceError::InternalError(e.to_string()))?;
+    let body = serde_json::to_vec(&request)?;
 
     let mut pkt = Vec::new();
     pkt.extend_from_slice(CDTUNNEL_MAGIC);

--- a/idevice/src/services/afc/file.rs
+++ b/idevice/src/services/afc/file.rs
@@ -14,11 +14,9 @@ use crate::{
 
 /// Handle for an open file on the device.
 ///
-/// This handle implements **async `Drop`** to automatically close the file for users who forget,
-/// but only on a **Tokio multi-threaded runtime**
-///
-///
-/// Consider calling `.close()`, it won't drop if expliclity closed
+/// Does **not** close the file descriptor on drop. Callers must invoke
+/// [`.close()`](Self::close) to release the device-side FD.
+/// The FD is reclaimed automatically when the AFC session ends.
 #[derive(Debug)]
 pub struct FileDescriptor<'a> {
     inner: Pin<Box<InnerFileDescriptor<'a>>>,
@@ -26,11 +24,9 @@ pub struct FileDescriptor<'a> {
 
 /// Owned handle for an open file on the device.
 ///
-/// This handle implements **async `Drop`** to automatically close the file for users who forget,
-/// but only on a **Tokio multi-threaded runtime**
-///
-///
-/// Consider calling `.close()`, it won't drop if expliclity closed
+/// Does **not** close the file descriptor on drop. Callers must invoke
+/// [`.close()`](Self::close) to release the device-side FD.
+/// The FD is reclaimed automatically when the AFC session ends.
 #[derive(Debug)]
 pub struct OwnedFileDescriptor {
     inner: Pin<Box<OwnedInnerFileDescriptor>>,

--- a/idevice/src/services/afc/inner_file.rs
+++ b/idevice/src/services/afc/inner_file.rs
@@ -444,39 +444,10 @@ crate::impl_trait_to_structs!(AsyncSeek for InnerFileDescriptor<'_>, OwnedInnerF
 
 crate::impl_trait_to_structs!(Drop for InnerFileDescriptor<'_>, OwnedInnerFileDescriptor; {
     fn drop(&mut self) {
+        self.pending_fut = None;
         if !self.dropped {
-            // The pending_fut (if Some) holds a Pin<&mut Self> derived from a
-            // raw pointer to this struct. Dropping it here ensures that
-            // mutable reference is released before we create a second one via
-            // Pin::new_unchecked(self) below. Two live &mut Self to the same
-            // struct is UB under Stacked Borrows even if neither is actively
-            // dereferenced.
-            self.pending_fut = None;
-
-            // Best-effort close-on-drop only works on a multi-thread tokio
-            // runtime. On wasm32 there's no such runtime; on a current-thread
-            // runtime `block_in_place` would panic. In both cases the caller
-            // must invoke `.close().await` explicitly to release the FD.
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                let handle = tokio::runtime::Handle::current();
-
-                if matches!(
-                    handle.runtime_flavor(),
-                    tokio::runtime::RuntimeFlavor::CurrentThread
-                ) {
-                    return;
-                }
-
-                tokio::task::block_in_place(move || {
-                    handle.block_on(async move {
-                        unsafe { Pin::new_unchecked(self) }
-                            .close_inner()
-                            .await
-                            .ok();
-                    })
-                });
-            }
+            debug_assert!(false, "AFC file descriptor for {:?} dropped without calling .close().await", self.path);
+            println!("error: AFC file descriptor dropped without calling .close().await ({})", self.path);
         }
     }
 });

--- a/idevice/src/services/afc/mod.rs
+++ b/idevice/src/services/afc/mod.rs
@@ -98,22 +98,7 @@ impl AfcClient {
     ) -> Result<Self, IdeviceError> {
         let mut lockdown = LockdownClient::connect(provider).await?;
 
-        #[cfg(feature = "openssl")]
         let legacy = lockdown
-            .get_value(Some("ProductVersion"), None)
-            .await
-            .ok()
-            .as_ref()
-            .and_then(|x| x.as_string())
-            .and_then(|x| x.split(".").next())
-            .and_then(|x| x.parse::<u8>().ok())
-            .map(|x| x < 5)
-            .unwrap_or(false);
-
-        #[cfg(not(feature = "openssl"))]
-        let legacy = false;
-
-        lockdown
             .start_session(&provider.get_pairing_file().await?)
             .await?;
 

--- a/idevice/src/services/crashreportcopymobile.rs
+++ b/idevice/src/services/crashreportcopymobile.rs
@@ -85,7 +85,9 @@ impl CrashReportCopyMobileClient {
             .open(format!("/{log}"), crate::afc::opcode::AfcFopenMode::RdOnly)
             .await?;
 
-        f.read_entire().await
+        let data = f.read_entire().await?;
+        f.close().await?;
+        Ok(data)
     }
 
     /// Removes a specified crash log file from the device.

--- a/idevice/src/services/crashreportcopymobile.rs
+++ b/idevice/src/services/crashreportcopymobile.rs
@@ -126,17 +126,6 @@ pub async fn flush_reports(
     let mut lockdown = LockdownClient::connect(provider).await?;
 
     let legacy = lockdown
-        .get_value(Some("ProductVersion"), None)
-        .await
-        .ok()
-        .as_ref()
-        .and_then(|x| x.as_string())
-        .and_then(|x| x.split(".").next())
-        .and_then(|x| x.parse::<u8>().ok())
-        .map(|x| x < 5)
-        .unwrap_or(false);
-
-    lockdown
         .start_session(&provider.get_pairing_file().await?)
         .await?;
 

--- a/idevice/src/services/dvt/mod.rs
+++ b/idevice/src/services/dvt/mod.rs
@@ -66,17 +66,6 @@ impl crate::IdeviceService for remote_server::RemoteServerClient<Box<dyn ReadWri
         let mut lockdown = LockdownClient::connect(provider).await?;
 
         let legacy = lockdown
-            .get_value(Some("ProductVersion"), None)
-            .await
-            .ok()
-            .as_ref()
-            .and_then(|x| x.as_string())
-            .and_then(|x| x.split(".").next())
-            .and_then(|x| x.parse::<u8>().ok())
-            .map(|x| x < 5)
-            .unwrap_or(false);
-
-        lockdown
             .start_session(&provider.get_pairing_file().await?)
             .await?;
 

--- a/idevice/src/services/lockdown.rs
+++ b/idevice/src/services/lockdown.rs
@@ -156,7 +156,8 @@ impl LockdownClient {
     /// * `pairing_file` - Contains the device's identity and certificates
     ///
     /// # Returns
-    /// `Ok(())` on successful session establishment
+    /// `Ok(legacy)` on successful session establishment, where `legacy` indicates
+    /// whether the device is running iOS < 5 and requires legacy TLS settings
     ///
     /// # Errors
     /// Returns `IdeviceError` if:
@@ -166,7 +167,7 @@ impl LockdownClient {
     pub async fn start_session(
         &mut self,
         pairing_file: &pairing_file::PairingFile,
-    ) -> Result<(), IdeviceError> {
+    ) -> Result<bool, IdeviceError> {
         if self.idevice.socket.is_none() {
             return Err(IdeviceError::NoEstablishedConnection);
         }
@@ -208,7 +209,7 @@ impl LockdownClient {
         }
 
         self.idevice.start_session(pairing_file, legacy).await?;
-        Ok(())
+        Ok(legacy)
     }
 
     /// Requests to start a service on the device
@@ -277,7 +278,7 @@ impl LockdownClient {
     ///
     /// # Errors
     /// Returns `IdeviceError`
-    #[cfg(all(feature = "pair", feature = "rustls"))]
+    #[cfg(feature = "pair")]
     pub async fn pair(
         &mut self,
         host_id: impl Into<String>,

--- a/idevice/src/tunnel.rs
+++ b/idevice/src/tunnel.rs
@@ -49,8 +49,7 @@ impl<R: ReadWrite> CdTunnel<R> {
             "type": "clientHandshakeRequest",
             "mtu": DEFAULT_MTU
         });
-        let body =
-            serde_json::to_vec(&request).map_err(|e| IdeviceError::InternalError(e.to_string()))?;
+        let body = serde_json::to_vec(&request)?;
 
         stream.write_all(CDTUNNEL_MAGIC).await?;
         stream.write_all(&(body.len() as u16).to_be_bytes()).await?;
@@ -74,8 +73,7 @@ impl<R: ReadWrite> CdTunnel<R> {
         let mut response_buf = vec![0u8; response_len];
         stream.read_exact(&mut response_buf).await?;
 
-        let response: serde_json::Value = serde_json::from_slice(&response_buf)
-            .map_err(|e| IdeviceError::InternalError(e.to_string()))?;
+        let response: serde_json::Value = serde_json::from_slice(&response_buf)?;
 
         debug!("CDTunnel handshake response: {response:#?}");
 

--- a/tests/src/afc.rs
+++ b/tests/src/afc.rs
@@ -42,10 +42,12 @@ async fn roundtrip(
     {
         let mut f = client.open(path, AfcFopenMode::WrOnly).await?;
         f.write_all(data).await?;
+        f.close().await?;
     }
     let mut f = client.open(path, AfcFopenMode::RdOnly).await?;
     let mut buf = Vec::new();
     f.read_to_end(&mut buf).await?;
+    f.close().await?;
     if buf != data {
         return Err(idevice::IdeviceError::UnexpectedResponse(format!(
             "roundtrip mismatch: wrote {} bytes, read {} bytes, content differs",
@@ -147,10 +149,12 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
             {
                 let mut f = client.open(&path, AfcFopenMode::WrOnly).await?;
                 f.write_entire(data).await?;
+                f.close().await?;
             }
             {
                 let mut f = client.open(&path, AfcFopenMode::RdOnly).await?;
                 let got = f.read_entire().await?;
+                f.close().await?;
                 if got != data {
                     return Err(idevice::IdeviceError::UnexpectedResponse(
                         "read_entire content mismatch".into(),
@@ -172,11 +176,13 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
             {
                 let mut f = client.open(&path, AfcFopenMode::WrOnly).await?;
                 f.write_all(data).await?;
+                f.close().await?;
             }
             {
                 let mut f = client.open(&path, AfcFopenMode::RdOnly).await?;
                 let mut buf = Vec::new();
                 f.read_to_end(&mut buf).await?;
+                f.close().await?;
                 if buf != data {
                     return Err(idevice::IdeviceError::UnexpectedResponse(
                         "async read content mismatch".into(),
@@ -191,13 +197,15 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
     run_test!("afc: zero-length file", success, failure, async {
         let path = p("empty.bin");
         {
-            let _ = client.open(&path, AfcFopenMode::WrOnly).await?;
-            // drop without writing — file exists but is empty
+            let f = client.open(&path, AfcFopenMode::WrOnly).await?;
+            // close without writing — file exists but is empty
+            f.close().await?;
         }
         {
             let mut f = client.open(&path, AfcFopenMode::RdOnly).await?;
             let mut buf = Vec::new();
             let n = f.read_to_end(&mut buf).await?;
+            f.close().await?;
             if n != 0 {
                 return Err(idevice::IdeviceError::UnexpectedResponse(
                     "expected 0 bytes from empty file".into(),
@@ -214,16 +222,19 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
             let mut f = client.open(&path, AfcFopenMode::WrOnly).await?;
             f.write_all(b"first\n").await?;
             f.flush().await?;
+            f.close().await?;
         }
         {
             let mut f = client.open(&path, AfcFopenMode::Append).await?;
             f.write_all(b"second\n").await?;
             f.flush().await?;
+            f.close().await?;
         }
         {
             let mut f = client.open(&path, AfcFopenMode::RdOnly).await?;
             let mut buf = Vec::new();
             f.read_to_end(&mut buf).await?;
+            f.close().await?;
             let s = String::from_utf8_lossy(&buf);
             if s != "first\nsecond\n" {
                 return Err(idevice::IdeviceError::UnexpectedResponse(format!(
@@ -277,11 +288,13 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
         {
             let mut f = client.open(&path, AfcFopenMode::WrOnly).await?;
             f.write_all(data).await?;
+            f.close().await?;
         }
         {
             let mut f = client.open(&path, AfcFopenMode::RdOnly).await?;
             f.seek(std::io::SeekFrom::Start(10)).await?;
             let pos = f.seek_tell().await?;
+            f.close().await?;
             if pos != 10 {
                 return Err(idevice::IdeviceError::UnexpectedResponse(format!(
                     "seek_tell returned {pos}, expected 10"
@@ -309,6 +322,7 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
             }
             let mut tail = [0u8; 5];
             f.read_exact(&mut tail).await?; // reads 5..10
+            f.close().await?;
             if &tail != b"56789" {
                 return Err(idevice::IdeviceError::UnexpectedResponse(format!(
                     "seek_current read wrong bytes: {:?}",
@@ -329,6 +343,7 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
             f.seek(std::io::SeekFrom::End(-5)).await?;
             let mut tail = Vec::new();
             f.read_to_end(&mut tail).await?;
+            f.close().await?;
             if &tail != b"BCDEF" {
                 return Err(idevice::IdeviceError::UnexpectedResponse(format!(
                     "seek_end wrong bytes: {:?}",
@@ -347,11 +362,13 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
             f.write_all(b"start").await?;
             f.seek(std::io::SeekFrom::Start(0)).await?;
             f.write_all(b"over").await?;
+            f.close().await?;
         }
         {
             let mut f = client.open(&path, AfcFopenMode::RdOnly).await?;
             let mut buf = Vec::new();
             f.read_to_end(&mut buf).await?;
+            f.close().await?;
             if &buf != b"overt" {
                 return Err(idevice::IdeviceError::UnexpectedResponse(format!(
                     "seek overwrite wrong content: {:?}",
@@ -383,6 +400,7 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
                 }
                 let mut rest = Vec::new();
                 f.read_to_end(&mut rest).await?;
+                f.close().await?;
                 if rest != b"fghijklmnopqrstuvwxyz" {
                     return Err(idevice::IdeviceError::UnexpectedResponse(
                         "partial read tail mismatch".into(),
@@ -413,6 +431,7 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
                     }
                     collected.push(b[0]);
                 }
+                f.close().await?;
                 if collected != data {
                     return Err(idevice::IdeviceError::UnexpectedResponse(
                         "one-byte read mismatch".into(),
@@ -474,11 +493,13 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
                     let chunk = vec![i; 100];
                     f.write_all(&chunk).await?;
                 }
+                f.close().await?;
             }
             {
                 let mut f = client.open(&path, AfcFopenMode::RdOnly).await?;
                 let mut buf = Vec::new();
                 f.read_to_end(&mut buf).await?;
+                f.close().await?;
                 if buf.len() != 1000 {
                     return Err(idevice::IdeviceError::UnexpectedResponse(format!(
                         "expected 1000 bytes, got {}",
@@ -523,6 +544,7 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
             let mut f = client.open(&dst, AfcFopenMode::RdOnly).await?;
             let mut buf = Vec::new();
             f.read_to_end(&mut buf).await?;
+            f.close().await?;
             if buf != data {
                 return Err(idevice::IdeviceError::UnexpectedResponse(
                     "renamed file content mismatch".into(),
@@ -586,10 +608,12 @@ pub async fn run_tests(provider: &dyn IdeviceProvider, success: &mut u32, failur
             {
                 let mut fa = client.open(&f1, AfcFopenMode::WrOnly).await?;
                 fa.write_all(b"a").await?;
+                fa.close().await?;
             }
             {
                 let mut fb = client.open(&f2, AfcFopenMode::WrOnly).await?;
                 fb.write_all(b"b").await?;
+                fb.close().await?;
             }
             let entries = client.list_dir(&dir).await?;
             if !entries.contains(&"a.txt".to_string()) || !entries.contains(&"b.txt".to_string()) {

--- a/tools/src/afc.rs
+++ b/tools/src/afc.rs
@@ -152,6 +152,7 @@ pub async fn main(arguments: &CollectedArguments, provider: Box<dyn IdeviceProvi
                 .expect("Failed to open");
 
             let res = file.read_entire().await.expect("Failed to read");
+            file.close().await.expect("Failed to close");
             tokio::fs::write(save, res)
                 .await
                 .expect("Failed to write to file");
@@ -169,6 +170,7 @@ pub async fn main(arguments: &CollectedArguments, provider: Box<dyn IdeviceProvi
             file.write_entire(&bytes)
                 .await
                 .expect("Failed to upload bytes");
+            file.close().await.expect("Failed to close");
         }
         "remove" => {
             let path = sub_args.next_argument::<String>().expect("No path passed");

--- a/tools/src/pair_apple_tv.rs
+++ b/tools/src/pair_apple_tv.rs
@@ -53,19 +53,16 @@ async fn main() {
 
     let host = "idevice-rs-jkcoxson";
     let mut rpf = RpPairingFile::generate(host);
-    let mut rpc = RemotePairingClient::new(conn, host, &mut rpf);
-    rpc.connect(
-        async |_| {
-            let mut buf = String::new();
-            print!("Enter the Apple TV pin: ");
-            std::io::stdout().flush().unwrap();
-            std::io::stdin()
-                .read_line(&mut buf)
-                .expect("Failed to read line");
-            buf.trim_end().to_string()
-        },
-        0u8, // we need no state, so pass a single byte that will hopefully get optimized out
-    )
+    let mut rpc = RemotePairingClient::new(conn, host);
+    rpc.connect(&mut rpf, async || {
+        let mut buf = String::new();
+        print!("Enter the Apple TV pin: ");
+        std::io::stdout().flush().unwrap();
+        std::io::stdin()
+            .read_line(&mut buf)
+            .expect("Failed to read line");
+        buf.trim_end().to_string()
+    })
     .await
     .expect("no pair");
 
@@ -77,13 +74,10 @@ async fn main() {
             .expect("Failed to connect");
     let conn = RpPairingSocket::new(conn);
 
-    let mut rpc = RemotePairingClient::new(conn, host, &mut rpf);
-    rpc.connect(
-        async |_| {
-            panic!("we tried to pair again :(");
-        },
-        0u8,
-    )
+    let mut rpc = RemotePairingClient::new(conn, host);
+    rpc.connect(&mut rpf, async || {
+        panic!("we tried to pair again :(");
+    })
     .await
     .expect("no reconnect");
 

--- a/tools/src/pair_rsd_ios.rs
+++ b/tools/src/pair_rsd_ios.rs
@@ -169,8 +169,8 @@ fn on_service_discovered(
                 RpPairingFile::generate(host)
             };
 
-            let mut rpc = RemotePairingClient::new(conn, host, &mut rpf);
-            rpc.connect(async |_| "000000".to_string(), 0u8)
+            let mut rpc = RemotePairingClient::new(conn, host);
+            rpc.connect(&mut rpf, async || "000000".to_string())
                 .await
                 .expect("pairing/verification failed");
 
@@ -323,14 +323,15 @@ async fn wifi_pair_flow(host_name: &str, service_address: &str, scope_id: Option
     let host = "idevice-rs-jkcoxson";
     let mut rpf = RpPairingFile::generate(host);
 
-    let mut rpc = RemotePairingClient::new(conn, host, &mut rpf);
+    let mut rpc = RemotePairingClient::new(conn, host);
 
     println!("Attempting pair verify / pair setup...");
     println!("(You may need to tap Trust on the device)");
 
     match rpc
         .connect(
-            async |_| {
+            &mut rpf,
+            async || {
                 println!("Enter the PIN shown on the device (or press enter for 000000):");
                 let mut input = String::new();
                 std::io::stdin().read_line(&mut input).ok();
@@ -341,7 +342,6 @@ async fn wifi_pair_flow(host_name: &str, service_address: &str, scope_id: Option
                     pin
                 }
             },
-            0u8,
         )
         .await
     {

--- a/tools/src/rppairing.rs
+++ b/tools/src/rppairing.rs
@@ -140,9 +140,9 @@ async fn pair_via_usb(provider: &dyn IdeviceProvider, hostname: &str, output_pat
     println!("(You may need to tap Trust on the device)");
 
     let mut rpf = RpPairingFile::generate(hostname);
-    let mut rpc = RemotePairingClient::new(conn, hostname, &mut rpf);
+    let mut rpc = RemotePairingClient::new(conn, hostname);
 
-    match rpc.connect(async |_| "000000".to_string(), 0u8).await {
+    match rpc.connect(&mut rpf, async || "000000".to_string()).await {
         Ok(()) => match rpf.write_to_file(output_path).await {
             Ok(()) => println!("Paired! Saved to {output_path}"),
             Err(e) => eprintln!("Failed to save pairing file: {e}"),


### PR DESCRIPTION
### Motivation

This fixes a borrow conflict where you can't save the pairing file while the `RemotePairingClient` is still alive, since the struct held a `&mut` borrow for its entire lifetime:

```
error[E0502]: cannot borrow `rpf` as immutable because it is also borrowed as mutable
  --> src/rsd.rs:103:9
   |
94 |     let mut rpc = RemotePairingClient::new(conn, SENDING_HOST, &mut rpf);
   |                                                                -------- mutable borrow occurs here
...
103|         rpf.write_to_file(&path)
   |         ^^^ immutable borrow occurs here
...
109|     rpc.create_tcp_listener();
   |     --- mutable borrow later used here
```

By moving the `&mut RpPairingFile` to a parameter on `connect()`, the borrow is released when `connect()` returns, so callers can freely use both `rpc` and `rpf` afterwards.

### Changes Made

- Remove `pairing_file: &'a mut RpPairingFile` from the `RemotePairingClient` struct, eliminating the `'a` lifetime parameter. Instead, `connect()` accepts `&mut RpPairingFile` by argument. The mutable borrow is now scoped to the function call rather than the struct's lifetime.
- Remove the `state: S` generic from `connect`, `pair`, and `request_pair_consent`. Callers can capture any needed state via move closures instead.
- Update all call sites in `tools/` and `ffi/` to match the new signatures.

### TypeState Pattern

This struct would be a good candidate for the TypeState pattern since it transitions through two distinct phases (unconnected, paired) where different operations are valid at each phase. Encoding these states as type parameters would make it a compile-time error to call `create_tcp_listener()` or `encryption_key()` before pairing completes, rather than relying on runtime checks and placeholder cipher values. I wasn't sure if that large of an API refactor would be in the interest of the project though. It would also almost certainly require `validate_pairing`/`pair` to become internal functions, since if they consume `self` to return a new type state, then `connect` can't do the "try validate first, fall back to pair on error" flow.