### PR TITLE
fix: make openssl PairingFile escrow_bag field Optional

### DIFF
--- a/idevice/src/pairing_file.rs
+++ b/idevice/src/pairing_file.rs
@@ -55,7 +55,7 @@ pub struct PairingFile {
     pub root_certificate: X509,
     pub system_buid: String,
     pub host_id: String,
-    pub escrow_bag: Vec<u8>,
+    pub escrow_bag: Option<Vec<u8>>,
     pub wifi_mac_address: String,
     pub udid: Option<String>,
 }


### PR DESCRIPTION
Fix openssl `PairingFile` `escrow_bag` type mismatch

The openssl-only `PairingFile` struct defined `escrow_bag` as `Vec<u8>`, but the underlying `RawPairingFile` has it as `Option<Data>` since `escrow_bag` can be `None` (e.g. on Apple Watch). The rustls variant already correctly used `Option<Vec<u8>>`.

This caused two compile errors when building with `--features openssl --no-default-features`:
- Line 244: `.map()` on `Option<Data>` returns `Option<Vec<u8>>`, which doesn't match `Vec<u8>`
- Line 292: `.map(Data::new)` called on `Vec<u8>`, which doesn't have a `.map()` method

The fix is just changing the openssl struct field to `Option<Vec<u8>>` to match. The conversion code was already written expecting `Option` -- the struct definition was the only thing wrong.
