### PR TITLE
fix: improve openssl crypto backend

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -24,6 +24,7 @@ windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock"] }
 [features]
 aws-lc = ["idevice/aws-lc"]
 ring = ["idevice/ring"]
+openssl = ["idevice/openssl"]
 
 
 afc = ["idevice/afc"]

--- a/ffi/src/lockdown.rs
+++ b/ffi/src/lockdown.rs
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn lockdownd_start_session(
     client: *mut LockdowndClientHandle,
     pairing_file: *mut IdevicePairingFile,
 ) -> *mut IdeviceFfiError {
-    let res: Result<(), IdeviceError> = run_sync_local(async move {
+    let res: Result<_, IdeviceError> = run_sync_local(async move {
         let client_ref = unsafe { &mut (*client).0 };
         let pairing_file_ref = unsafe { &(*pairing_file).0 };
 

--- a/idevice/src/lib.rs
+++ b/idevice/src/lib.rs
@@ -115,17 +115,6 @@ pub trait IdeviceService: Sized {
         let mut lockdown = LockdownClient::connect(provider).await?;
 
         let legacy = lockdown
-            .get_value(Some("ProductVersion"), None)
-            .await
-            .ok()
-            .as_ref()
-            .and_then(|x| x.as_string())
-            .and_then(|x| x.split(".").next())
-            .and_then(|x| x.parse::<u8>().ok())
-            .map(|x| x < 5)
-            .unwrap_or(false);
-
-        lockdown
             .start_session(&provider.get_pairing_file().await?)
             .await?;
         // Best-effort fetch UDID for downstream defaults (e.g., MobileBackup2 Target/Source identifiers)

--- a/idevice/src/lib.rs
+++ b/idevice/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(missing_copy_implementations)]
 // Jackson Coxson
 
-#[cfg(all(feature = "pair", feature = "rustls"))]
+#[cfg(feature = "pair")]
 mod ca;
 pub mod cursor;
 mod obfuscation;
@@ -114,7 +114,6 @@ pub trait IdeviceService: Sized {
     async fn connect(provider: &dyn IdeviceProvider) -> Result<Self, IdeviceError> {
         let mut lockdown = LockdownClient::connect(provider).await?;
 
-        #[cfg(feature = "openssl")]
         let legacy = lockdown
             .get_value(Some("ProductVersion"), None)
             .await
@@ -125,9 +124,6 @@ pub trait IdeviceService: Sized {
             .and_then(|x| x.parse::<u8>().ok())
             .map(|x| x < 5)
             .unwrap_or(false);
-
-        #[cfg(not(feature = "openssl"))]
-        let legacy = false;
 
         lockdown
             .start_session(&provider.get_pairing_file().await?)
@@ -705,7 +701,7 @@ impl Idevice {
                 connector.set_options(openssl::ssl::SslOptions::ALLOW_UNSAFE_LEGACY_RENEGOTIATION);
             }
 
-            let mut connector = connector.build().configure()?.into_ssl("ur mom")?;
+            let mut connector = connector.build().configure()?.into_ssl("Device")?;
 
             connector.set_certificate(&pairing_file.host_certificate)?;
             connector.set_private_key(&pairing_file.host_private_key)?;

--- a/idevice/src/pairing_file.rs
+++ b/idevice/src/pairing_file.rs
@@ -296,6 +296,7 @@ impl TryFrom<PairingFile> for RawPairingFile {
     }
 }
 
+#[cfg(feature = "rustls")]
 /// Helper function to ensure data has proper PEM headers
 /// If the data already has headers, it returns it as is
 /// If not, it adds the appropriate BEGIN and END headers
@@ -339,6 +340,7 @@ fn ensure_pem_headers(data: &[u8], pem_type: &str) -> Vec<u8> {
     result
 }
 
+#[cfg(feature = "rustls")]
 /// Check if data is already in PEM format
 fn is_pem_formatted(data: &[u8]) -> bool {
     if let Ok(data_str) = std::str::from_utf8(data) {
@@ -348,6 +350,7 @@ fn is_pem_formatted(data: &[u8]) -> bool {
     }
 }
 
+#[cfg(feature = "rustls")]
 /// Check if data is already base64 encoded
 fn is_base64(data: &[u8]) -> bool {
     if let Ok(data_str) = std::str::from_utf8(data) {

--- a/idevice/src/services/afc/mod.rs
+++ b/idevice/src/services/afc/mod.rs
@@ -98,7 +98,6 @@ impl AfcClient {
     ) -> Result<Self, IdeviceError> {
         let mut lockdown = LockdownClient::connect(provider).await?;
 
-        #[cfg(feature = "openssl")]
         let legacy = lockdown
             .get_value(Some("ProductVersion"), None)
             .await
@@ -109,9 +108,6 @@ impl AfcClient {
             .and_then(|x| x.parse::<u8>().ok())
             .map(|x| x < 5)
             .unwrap_or(false);
-
-        #[cfg(not(feature = "openssl"))]
-        let legacy = false;
 
         lockdown
             .start_session(&provider.get_pairing_file().await?)

--- a/idevice/src/services/afc/mod.rs
+++ b/idevice/src/services/afc/mod.rs
@@ -99,17 +99,6 @@ impl AfcClient {
         let mut lockdown = LockdownClient::connect(provider).await?;
 
         let legacy = lockdown
-            .get_value(Some("ProductVersion"), None)
-            .await
-            .ok()
-            .as_ref()
-            .and_then(|x| x.as_string())
-            .and_then(|x| x.split(".").next())
-            .and_then(|x| x.parse::<u8>().ok())
-            .map(|x| x < 5)
-            .unwrap_or(false);
-
-        lockdown
             .start_session(&provider.get_pairing_file().await?)
             .await?;
 

--- a/idevice/src/services/crashreportcopymobile.rs
+++ b/idevice/src/services/crashreportcopymobile.rs
@@ -126,17 +126,6 @@ pub async fn flush_reports(
     let mut lockdown = LockdownClient::connect(provider).await?;
 
     let legacy = lockdown
-        .get_value(Some("ProductVersion"), None)
-        .await
-        .ok()
-        .as_ref()
-        .and_then(|x| x.as_string())
-        .and_then(|x| x.split(".").next())
-        .and_then(|x| x.parse::<u8>().ok())
-        .map(|x| x < 5)
-        .unwrap_or(false);
-
-    lockdown
         .start_session(&provider.get_pairing_file().await?)
         .await?;
 

--- a/idevice/src/services/dvt/mod.rs
+++ b/idevice/src/services/dvt/mod.rs
@@ -66,17 +66,6 @@ impl crate::IdeviceService for remote_server::RemoteServerClient<Box<dyn ReadWri
         let mut lockdown = LockdownClient::connect(provider).await?;
 
         let legacy = lockdown
-            .get_value(Some("ProductVersion"), None)
-            .await
-            .ok()
-            .as_ref()
-            .and_then(|x| x.as_string())
-            .and_then(|x| x.split(".").next())
-            .and_then(|x| x.parse::<u8>().ok())
-            .map(|x| x < 5)
-            .unwrap_or(false);
-
-        lockdown
             .start_session(&provider.get_pairing_file().await?)
             .await?;
 

--- a/idevice/src/services/lockdown.rs
+++ b/idevice/src/services/lockdown.rs
@@ -156,7 +156,8 @@ impl LockdownClient {
     /// * `pairing_file` - Contains the device's identity and certificates
     ///
     /// # Returns
-    /// `Ok(())` on successful session establishment
+    /// `Ok(legacy)` on successful session establishment, where `legacy` indicates
+    /// whether the device is running iOS < 5 and requires legacy TLS settings
     ///
     /// # Errors
     /// Returns `IdeviceError` if:
@@ -166,7 +167,7 @@ impl LockdownClient {
     pub async fn start_session(
         &mut self,
         pairing_file: &pairing_file::PairingFile,
-    ) -> Result<(), IdeviceError> {
+    ) -> Result<bool, IdeviceError> {
         if self.idevice.socket.is_none() {
             return Err(IdeviceError::NoEstablishedConnection);
         }
@@ -208,7 +209,7 @@ impl LockdownClient {
         }
 
         self.idevice.start_session(pairing_file, legacy).await?;
-        Ok(())
+        Ok(legacy)
     }
 
     /// Requests to start a service on the device

--- a/idevice/src/services/lockdown.rs
+++ b/idevice/src/services/lockdown.rs
@@ -277,7 +277,7 @@ impl LockdownClient {
     ///
     /// # Errors
     /// Returns `IdeviceError`
-    #[cfg(all(feature = "pair", feature = "rustls"))]
+    #[cfg(feature = "pair")]
     pub async fn pair(
         &mut self,
         host_id: impl Into<String>,


### PR DESCRIPTION
Improve the openssl crypto backend, matching rustls in functionality.

The main issue was that `ca.rs` and `pair()` were gated on `rustls` even though they only use pure Rust crates (`rsa`, `x509-cert`, `sha2`, `web-time`) — no rustls APIs at all. This meant device pairing was completely unavailable when building with openssl.

Changes:

- Un-gate `ca.rs` module from `rustls` — now only requires `pair` feature
- Un-gate `pair()` in `LockdownClient` — same, just needs `pair`
- `LockdownClient::start_session` now returns the legacy flag (`Result<bool, IdeviceError>`) instead of `Result<(), _>`. Four callers were each querying `ProductVersion` separately before calling `start_session`, which also queries it internally — that's two round-trips to the device for the same value. Now the callers just use the returned flag.
- Add `openssl` feature to the FFI crate alongside `aws-lc` and `ring`
- Fix the SNI server name in the openssl `start_session` from a placeholder to `"Device"` (matching the rustls path)
- Gate `ensure_pem_headers`/`is_pem_formatted`/`is_base64` helpers behind `rustls` feature since they're only used by the rustls `PairingFile` impl — removes dead code warnings on openssl builds
