### PR TITLE
Make connect_tls_psk_tunnel and connect_tls_psk_tunnel_native generic

### DIFF
--- a/ffi/src/tunnel_provider.rs
+++ b/ffi/src/tunnel_provider.rs
@@ -44,8 +44,7 @@ async fn finish_tunnel(
     let tunnel_stream = tokio::net::TcpStream::connect(tunnel_addr)
         .await
         .map_err(|e| IdeviceError::InternalError(format!("TLS tunnel: {e}")))?;
-    let tunnel =
-        connect_tls_psk_tunnel_native(Box::new(tunnel_stream), rpc.encryption_key()).await?;
+    let tunnel = connect_tls_psk_tunnel_native(tunnel_stream, rpc.encryption_key()).await?;
 
     let client_ip: std::net::IpAddr = tunnel
         .info

--- a/idevice/src/remote_pairing/tunnel.rs
+++ b/idevice/src/remote_pairing/tunnel.rs
@@ -21,10 +21,10 @@ const DEFAULT_MTU: u16 = 16000;
 ///
 /// This uses a built-in TLS 1.2 PSK-AES256-CBC-SHA384 implementation with no
 /// external TLS library dependency.
-pub async fn connect_tls_psk_tunnel_native(
-    stream: Box<dyn ReadWrite>,
+pub async fn connect_tls_psk_tunnel_native<S: ReadWrite>(
+    stream: S,
     encryption_key: &[u8],
-) -> Result<CdTunnel<super::tls_psk::TlsPskStream<Box<dyn ReadWrite>>>, IdeviceError> {
+) -> Result<CdTunnel<super::tls_psk::TlsPskStream<S>>, IdeviceError> {
     let mut tls_stream = super::tls_psk::tls_psk_handshake(stream, encryption_key).await?;
     debug!("Native TLS-PSK handshake complete");
 
@@ -127,10 +127,10 @@ pub async fn connect_tls_psk_tunnel_native(
 /// Requires the `openssl` feature. Consider using [`connect_tls_psk_tunnel_native`]
 /// instead, which has no external dependency.
 #[cfg(feature = "openssl")]
-pub async fn connect_tls_psk_tunnel(
-    stream: tokio::net::TcpStream,
+pub async fn connect_tls_psk_tunnel<S: ReadWrite>(
+    stream: S,
     encryption_key: &[u8],
-) -> Result<CdTunnel<tokio_openssl::SslStream<tokio::net::TcpStream>>, IdeviceError> {
+) -> Result<CdTunnel<tokio_openssl::SslStream<S>>, IdeviceError> {
     use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 
     let psk = encryption_key.to_vec();

--- a/tools/src/core_device_proxy_tun.rs
+++ b/tools/src/core_device_proxy_tun.rs
@@ -2,8 +2,8 @@
 
 use clap::{Arg, Command};
 use idevice::{
-    core_device_proxy::{self},
     IdeviceService,
+    core_device_proxy::{self},
 };
 use tun_rs::AbstractDevice;
 
@@ -74,8 +74,7 @@ async fn main() {
         32,
     )
     .unwrap();
-    dev.set_mtu(tun_proxy.tunnel_info().mtu)
-        .unwrap();
+    dev.set_mtu(tun_proxy.tunnel_info().mtu).unwrap();
     dev.set_network_address(
         tun_proxy.tunnel_info().client_address.clone(),
         tun_proxy


### PR DESCRIPTION
Make `connect_tls_psk_tunnel` and `connect_tls_psk_tunnel_native` generic over any `S: ReadWrite` instead of requiring `Box<dyn ReadWrite>` or `TcpStream` specifically.

This lets callers pass any stream type directly without boxing. The underlying implementations (`tls_psk_handshake` and `tokio_openssl::SslStream::new`) were already generic, so this just threads that genericity through to the public API.

Changes:
- `connect_tls_psk_tunnel_native`: `Box<dyn ReadWrite>` -> `S: ReadWrite`
- `connect_tls_psk_tunnel`: `tokio::net::TcpStream` -> `S: ReadWrite`
- Removed unnecessary `Box::new()` wrapping in `tunnel_provider.rs`
