### PR TITLE
fix(mobilebackup2): resolve device-supplied DeviceLink paths under the backup dir

### DIFF
--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -6,7 +6,7 @@
 use plist::Dictionary;
 use std::future::Future;
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
 use std::time::SystemTime;
 use tokio::io::AsyncReadExt;
@@ -28,6 +28,25 @@ pub struct DirEntryInfo {
     pub is_file: bool,
     pub size: u64,
     pub modified: Option<SystemTime>,
+}
+
+/// Resolves a device-supplied DeviceLink path against the host backup directory.
+///
+/// During a backup the device sends paths for the host to read/write/move. Some
+/// of these are absolute-looking (e.g. `/.b/6/...`). Passing them straight to
+/// [`Path::join`] is unsafe: Rust drops the base when the argument is absolute,
+/// so the operation escapes the backup directory which can cause "Operation
+/// not permitted" errors that abort the backup or read/write outside
+/// it (path traversal). Treat the device path as strictly relative to
+/// `host_dir`, keeping only `Normal` components (dropping any root, `.` or `..`).
+fn host_path(host_dir: &Path, rel: &str) -> PathBuf {
+    let mut out = host_dir.to_path_buf();
+    for comp in Path::new(rel).components() {
+        if let Component::Normal(c) = comp {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// Delegate trait providing host-side storage and platform operations for the
@@ -1150,7 +1169,7 @@ impl MobileBackup2Client {
         rel_path: &str,
         delegate: &dyn BackupDelegate,
     ) -> Result<(), IdeviceError> {
-        let full = host_dir.join(rel_path);
+        let full = host_path(host_dir, rel_path);
         let path_bytes = rel_path.as_bytes().to_vec();
         let nlen = (path_bytes.len() as u32).to_be_bytes();
         self.idevice.send_raw(&nlen).await?;
@@ -1225,7 +1244,7 @@ impl MobileBackup2Client {
             }
             let fname = self.read_exact_string(flen as usize).await?;
 
-            let dst = host_dir.join(&fname);
+            let dst = host_path(host_dir, &fname);
             if let Some(parent) = dst.parent() {
                 let _ = delegate.create_dir_all(parent).await;
             }
@@ -1302,7 +1321,7 @@ impl MobileBackup2Client {
             && arr.len() >= 2
             && let Some(plist::Value::String(dir)) = arr.get(1)
         {
-            let path = host_dir.join(dir);
+            let path = host_path(host_dir, dir);
             return match delegate.create_dir_all(&path).await {
                 Ok(_) => 0,
                 Err(_) => -1,
@@ -1322,8 +1341,8 @@ impl MobileBackup2Client {
         {
             for (from, to_v) in map.iter() {
                 if let Some(to) = to_v.as_string() {
-                    let old = host_dir.join(from);
-                    let newp = host_dir.join(to);
+                    let old = host_path(host_dir, from);
+                    let newp = host_path(host_dir, to);
                     if let Some(parent) = newp.parent() {
                         let _ = delegate.create_dir_all(parent).await;
                     }
@@ -1348,7 +1367,7 @@ impl MobileBackup2Client {
         {
             for it in items {
                 if let Some(p) = it.as_string() {
-                    let path = host_dir.join(p);
+                    let path = host_path(host_dir, p);
                     if delegate.exists(&path).await && delegate.remove(&path).await.is_err() {
                         return -1;
                     }
@@ -1369,8 +1388,8 @@ impl MobileBackup2Client {
             && let (Some(plist::Value::String(src)), Some(plist::Value::String(dst))) =
                 (arr.get(1), arr.get(2))
         {
-            let from = host_dir.join(src);
-            let to = host_dir.join(dst);
+            let from = host_path(host_dir, src);
+            let to = host_path(host_dir, dst);
             if let Some(parent) = to.parent() {
                 let _ = delegate.create_dir_all(parent).await;
             }
@@ -1641,7 +1660,7 @@ impl MobileBackup2Client {
             return plist::Value::Dictionary(dirlist);
         };
 
-        let full_path = host_dir.join(&rel_path);
+        let full_path = host_path(host_dir, &rel_path);
         if let Ok(entries) = delegate.list_dir(&full_path).await {
             for entry in entries {
                 let mut fdict = Dictionary::new();


### PR DESCRIPTION
## Problem

The mobilebackup2 DeviceLink loop builds host paths for the device's
read/write/move/copy/remove/mkdir/list requests with `host_dir.join(rel)`, where
`rel` comes straight from the device. During a backup the device sometimes sends
**absolute-looking** paths (e.g. `/.b/6/Containers/.../Foo.sqlite`), and Rust's
[`Path::join`] **discards the base when the argument is absolute**:

```rust
Path::new("/tmp/backup").join("/.b/6/x") // == "/.b/6/x", NOT under the backup dir
```

So the host then opens/creates the file under the filesystem root instead of the
backup directory.

### Impact

1. **Aborts real backups.** Opening `/.b/6/.../Foo.sqlite` fails with `EPERM`
   ("Operation not permitted") instead of the `ENOENT` the device tolerates, and
   the device aborts the whole backup with `ErrorCode 24`:

   ```
   device backup error 24: open error: Operation not permitted (1) at path
   "/.b/6/Containers/Data/Application/.../FGTS.sqlite" (MBErrorDomain/24)
   ```

2. **Path traversal.** A device-supplied path with a leading `/` or `..` can make
   the host read or write **outside** the backup directory.

## Fix

Add a small `host_path()` helper that treats the device path as **strictly
relative** to the backup dir — keeping only `Normal` path components and dropping
any root / `.` / `..` — and use it at all 8 join sites. This matches
libimobiledevice's `idevicebackup2`, which concatenates the device path under the
backup directory.

```rust
fn host_path(host_dir: &Path, rel: &str) -> PathBuf {
    let mut out = host_dir.to_path_buf();
    for comp in Path::new(rel).components() {
        if let Component::Normal(c) = comp {
            out.push(c);
        }
    }
    out
}
```

No behaviour change for ordinary relative paths; only the absolute / traversal
cases are corrected.

## Verification

Driving a full **encrypted** backup with a `BackupDelegate` previously aborted at
`ErrorCode 24` on the first such path; with this change the backup completes
end-to-end (206k files, then decrypts cleanly). `cargo build` / `cargo fmt
--check` clean for `-p idevice --features mobilebackup2,usbmuxd`.
