### PR TITLE
fix(mobilebackup2): report real free disk space in FsBackupDelegate

### DIFF
--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -111,11 +111,6 @@ pub trait BackupDelegate: Send + Sync {
 
 /// Default [`BackupDelegate`] that reads/writes to the local filesystem via `tokio::fs`.
 ///
-/// [`get_free_disk_space`](BackupDelegate::get_free_disk_space) reports real free
-/// space via `statfs`/`statvfs` on Unix and `GetDiskFreeSpaceExW` on Windows;
-/// platforms without an OS query report a large constant (a backup host is assumed
-/// to have room). Override for exact accounting.
-///
 /// Native-only: `tokio::fs` doesn't compile on `wasm32-unknown-unknown`.
 /// Wasm consumers must implement their own [`BackupDelegate`] backed by
 /// IndexedDB / OPFS / an in-memory store / etc.
@@ -128,15 +123,12 @@ impl BackupDelegate for FsBackupDelegate {
     /// Free space in bytes available to an unprivileged user on the volume backing
     /// `path` (resolved through symlinks and mount points), walking up to the
     /// nearest existing ancestor. Where the OS can't be queried it reports a large
-    /// constant instead of `0`, since a backup host is assumed to have room.
+    /// constant.
     fn get_free_disk_space(&self, path: &Path) -> u64 {
-        // Returned when the OS can't tell us — no query on this platform, or the
-        // path resolved to nothing: assume the host has room rather than `0`.
-        const ASSUMED_FREE: u64 = 1 << 50; // ~1 PiB, far above any device backup
+        const ASSUMED_FREE: u64 = 1 << 50;
 
         // Available bytes on the volume backing an existing `p`, or `None` if the
-        // query fails (e.g. `p` doesn't exist yet). Interior-NUL paths — which no
-        // real path has — return `None` so the caller walks up to a usable parent.
+        // query fails (e.g. `p` doesn't exist yet).
         #[allow(clippy::unnecessary_cast)] // block-count/size widths vary per platform
         fn available(p: &Path) -> Option<u64> {
             #[cfg(unix)]
@@ -144,8 +136,7 @@ impl BackupDelegate for FsBackupDelegate {
                 use std::os::unix::ffi::OsStrExt;
                 let c = std::ffi::CString::new(p.as_os_str().as_bytes()).ok()?;
                 // Apple's `statvfs` f_bavail is a 32-bit count that rolls over past
-                // ~4 TB free; `statfs` is 64-bit. Use `statfs` on Apple, `statvfs`
-                // elsewhere — both give bytes as `f_bavail * (block size)`.
+                // ~4 TB free; `statfs` is 64-bit.
                 #[cfg(target_vendor = "apple")]
                 {
                     let mut s = std::mem::MaybeUninit::<libc::statfs>::uninit();
@@ -1801,8 +1792,6 @@ mod tests {
 
     #[test]
     fn fs_delegate_reports_real_free_space() {
-        // The stock delegate must report real space — returning 0 makes the
-        // device abort the backup with ErrorCode 105.
         let free = FsBackupDelegate.get_free_disk_space(Path::new("."));
         assert!(free > 0, "expected non-zero free space, got {free}");
     }

--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -111,8 +111,9 @@ pub trait BackupDelegate: Send + Sync {
 
 /// Default [`BackupDelegate`] that reads/writes to the local filesystem via `tokio::fs`.
 ///
-/// Returns `0` for [`get_free_disk_space`](BackupDelegate::get_free_disk_space);
-/// override or wrap this if you need real disk-space reporting.
+/// [`get_free_disk_space`](BackupDelegate::get_free_disk_space) reports real free
+/// space via `statvfs` on Unix; on other platforms it returns `0` (override if
+/// you need disk-space reporting there).
 ///
 /// Native-only: `tokio::fs` doesn't compile on `wasm32-unknown-unknown`.
 /// Wasm consumers must implement their own [`BackupDelegate`] backed by
@@ -123,8 +124,38 @@ pub struct FsBackupDelegate;
 
 #[cfg(not(target_arch = "wasm32"))]
 impl BackupDelegate for FsBackupDelegate {
-    fn get_free_disk_space(&self, _path: &Path) -> u64 {
-        0
+    /// Free space (bytes available to an unprivileged user) on the volume holding
+    /// `path`, walking up to the nearest existing ancestor. Returning `0` here
+    /// makes the device abort the backup with `ErrorCode 105` (insufficient
+    /// space), so the default needs a real value.
+    fn get_free_disk_space(&self, path: &Path) -> u64 {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            let mut dir = path;
+            loop {
+                if let Ok(c) = std::ffi::CString::new(dir.as_os_str().as_bytes()) {
+                    let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+                    // SAFETY: `c` is a valid NUL-terminated path and `stat` is
+                    // a correctly sized, writable `statvfs` buffer.
+                    if unsafe { libc::statvfs(c.as_ptr(), stat.as_mut_ptr()) } == 0 {
+                        let stat = unsafe { stat.assume_init() };
+                        // `f_bavail` / `f_frsize` widths differ per platform; cast both.
+                        #[allow(clippy::unnecessary_cast)]
+                        return stat.f_bavail as u64 * stat.f_frsize as u64;
+                    }
+                }
+                match dir.parent() {
+                    Some(parent) => dir = parent,
+                    None => return 0,
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+            0
+        }
     }
 
     fn open_file_read<'a>(
@@ -1701,5 +1732,25 @@ impl crate::RsdService for MobileBackup2Client {
         client.dl_version_exchange().await?;
         client.version_exchange().await?;
         Ok(client)
+    }
+}
+
+#[cfg(all(test, unix, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fs_delegate_reports_real_free_space() {
+        // The stock delegate must report real space — returning 0 makes the
+        // device abort the backup with ErrorCode 105.
+        let free = FsBackupDelegate.get_free_disk_space(Path::new("."));
+        assert!(free > 0, "expected non-zero free space, got {free}");
+    }
+
+    #[test]
+    fn fs_delegate_free_space_walks_up_to_existing_ancestor() {
+        let free = FsBackupDelegate
+            .get_free_disk_space(Path::new("./does/not/exist/anywhere/right/now"));
+        assert!(free > 0, "should statvfs an existing ancestor, got {free}");
     }
 }

--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -112,8 +112,8 @@ pub trait BackupDelegate: Send + Sync {
 /// Default [`BackupDelegate`] that reads/writes to the local filesystem via `tokio::fs`.
 ///
 /// [`get_free_disk_space`](BackupDelegate::get_free_disk_space) reports real free
-/// space via `statvfs` on Unix; on other platforms it returns `0` (override if
-/// you need disk-space reporting there).
+/// space via `statvfs` on Unix and `GetDiskFreeSpaceExW` on Windows; on other
+/// platforms it returns `0` (override if you need disk-space reporting there).
 ///
 /// Native-only: `tokio::fs` doesn't compile on `wasm32-unknown-unknown`.
 /// Wasm consumers must implement their own [`BackupDelegate`] backed by
@@ -128,6 +128,12 @@ impl BackupDelegate for FsBackupDelegate {
     /// `path`, walking up to the nearest existing ancestor. Returning `0` here
     /// makes the device abort the backup with `ErrorCode 105` (insufficient
     /// space), so the default needs a real value.
+    ///
+    /// Symlinks and mount points are resolved by the OS: `statvfs` /
+    /// `GetDiskFreeSpaceExW` both report the volume that actually backs `path`
+    /// (i.e. where backup data lands), which is the figure the device wants.
+    /// A path containing an interior NUL — which no real filesystem path has —
+    /// is skipped and the walk-up continues to the nearest NUL-free ancestor.
     fn get_free_disk_space(&self, path: &Path) -> u64 {
         #[cfg(unix)]
         {
@@ -151,7 +157,53 @@ impl BackupDelegate for FsBackupDelegate {
                 }
             }
         }
-        #[cfg(not(unix))]
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStrExt;
+            // kernel32!GetDiskFreeSpaceExW — no new dependency, mirrors the raw
+            // `libc::statvfs` FFI above. `lpFreeBytesAvailableToCaller` is already
+            // 64-bit bytes available to the caller (honouring quotas), so there is
+            // no block-count multiplication and no per-platform width concern.
+            #[link(name = "kernel32")]
+            unsafe extern "system" {
+                fn GetDiskFreeSpaceExW(
+                    lpDirectoryName: *const u16,
+                    lpFreeBytesAvailableToCaller: *mut u64,
+                    lpTotalNumberOfBytes: *mut u64,
+                    lpTotalNumberOfFreeBytes: *mut u64,
+                ) -> i32;
+            }
+            let mut dir = path;
+            loop {
+                let mut wide: Vec<u16> = dir.as_os_str().encode_wide().collect();
+                // Reject an interior NUL (impossible in a real path): a premature
+                // wide-string terminator would silently query the wrong path.
+                // Skip to the parent, mirroring `CString::new` on Unix.
+                if !wide.contains(&0) {
+                    wide.push(0);
+                    let mut avail: u64 = 0;
+                    // SAFETY: `wide` is a valid NUL-terminated UTF-16 path; the
+                    // three out-params are writable `u64` (`ULARGE_INTEGER`) slots,
+                    // and `avail` is read only when the call reports success.
+                    if unsafe {
+                        GetDiskFreeSpaceExW(
+                            wide.as_ptr(),
+                            &mut avail,
+                            std::ptr::null_mut(),
+                            std::ptr::null_mut(),
+                        )
+                    } != 0
+                    {
+                        return avail;
+                    }
+                }
+                match dir.parent() {
+                    Some(parent) => dir = parent,
+                    None => return 0,
+                }
+            }
+        }
+        #[cfg(not(any(unix, windows)))]
         {
             let _ = path;
             0
@@ -1735,7 +1787,7 @@ impl crate::RsdService for MobileBackup2Client {
     }
 }
 
-#[cfg(all(test, unix, not(target_arch = "wasm32")))]
+#[cfg(all(test, any(unix, windows), not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
 
@@ -1749,8 +1801,8 @@ mod tests {
 
     #[test]
     fn fs_delegate_free_space_walks_up_to_existing_ancestor() {
-        let free = FsBackupDelegate
-            .get_free_disk_space(Path::new("./does/not/exist/anywhere/right/now"));
-        assert!(free > 0, "should statvfs an existing ancestor, got {free}");
+        let free =
+            FsBackupDelegate.get_free_disk_space(Path::new("./does/not/exist/anywhere/right/now"));
+        assert!(free > 0, "should resolve an existing ancestor, got {free}");
     }
 }

--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -112,8 +112,8 @@ pub trait BackupDelegate: Send + Sync {
 /// Default [`BackupDelegate`] that reads/writes to the local filesystem via `tokio::fs`.
 ///
 /// [`get_free_disk_space`](BackupDelegate::get_free_disk_space) reports real free
-/// space via `statvfs` on Unix and `GetDiskFreeSpaceExW` on Windows; on other
-/// platforms it returns `0` (override if you need disk-space reporting there).
+/// space via `statfs`/`statvfs` on Unix and `GetDiskFreeSpaceExW` on Windows; on
+/// other platforms it returns `0` (override if you need disk-space reporting there).
 ///
 /// Native-only: `tokio::fs` doesn't compile on `wasm32-unknown-unknown`.
 /// Wasm consumers must implement their own [`BackupDelegate`] backed by
@@ -141,14 +141,35 @@ impl BackupDelegate for FsBackupDelegate {
             let mut dir = path;
             loop {
                 if let Ok(c) = std::ffi::CString::new(dir.as_os_str().as_bytes()) {
-                    let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
-                    // SAFETY: `c` is a valid NUL-terminated path and `stat` is
-                    // a correctly sized, writable `statvfs` buffer.
-                    if unsafe { libc::statvfs(c.as_ptr(), stat.as_mut_ptr()) } == 0 {
-                        let stat = unsafe { stat.assume_init() };
-                        // `f_bavail` / `f_frsize` widths differ per platform; cast both.
-                        #[allow(clippy::unnecessary_cast)]
-                        return stat.f_bavail as u64 * stat.f_frsize as u64;
+                    // Apple's `statvfs` reports `f_bavail` through a 32-bit
+                    // `fsblkcnt_t`, which rolls over for volumes with more than
+                    // ~4 TB free — Darwin does not scale `f_frsize` to compensate
+                    // (rust-lang/libc; Apple Libc). `statfs` exposes a 64-bit
+                    // `f_bavail`, so use it on Apple targets and `statvfs` elsewhere.
+                    #[cfg(target_vendor = "apple")]
+                    {
+                        let mut stat = std::mem::MaybeUninit::<libc::statfs>::uninit();
+                        // SAFETY: `c` is a valid NUL-terminated path and `stat` is
+                        // a correctly sized, writable `statfs` buffer.
+                        if unsafe { libc::statfs(c.as_ptr(), stat.as_mut_ptr()) } == 0 {
+                            let stat = unsafe { stat.assume_init() };
+                            // `f_bavail` is in units of `f_bsize` for `statfs`.
+                            #[allow(clippy::unnecessary_cast)]
+                            return stat.f_bavail as u64 * stat.f_bsize as u64;
+                        }
+                    }
+                    #[cfg(not(target_vendor = "apple"))]
+                    {
+                        let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+                        // SAFETY: `c` is a valid NUL-terminated path and `stat` is
+                        // a correctly sized, writable `statvfs` buffer.
+                        if unsafe { libc::statvfs(c.as_ptr(), stat.as_mut_ptr()) } == 0 {
+                            let stat = unsafe { stat.assume_init() };
+                            // `f_bavail` is in units of `f_frsize` for `statvfs`;
+                            // widths differ per platform, so cast both.
+                            #[allow(clippy::unnecessary_cast)]
+                            return stat.f_bavail as u64 * stat.f_frsize as u64;
+                        }
                     }
                 }
                 match dir.parent() {

--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -124,110 +124,92 @@ pub struct FsBackupDelegate;
 
 #[cfg(not(target_arch = "wasm32"))]
 impl BackupDelegate for FsBackupDelegate {
-    /// Free space (bytes available to an unprivileged user) on the volume holding
-    /// `path`, walking up to the nearest existing ancestor. Returning `0` here
-    /// makes the device abort the backup with `ErrorCode 105` (insufficient
-    /// space), so the default needs a real value.
-    ///
-    /// Symlinks and mount points are resolved by the OS: `statvfs` /
-    /// `GetDiskFreeSpaceExW` both report the volume that actually backs `path`
-    /// (i.e. where backup data lands), which is the figure the device wants.
-    /// A path containing an interior NUL — which no real filesystem path has —
-    /// is skipped and the walk-up continues to the nearest NUL-free ancestor.
+    /// Free space in bytes available to an unprivileged user on the volume
+    /// backing `path` (resolved through symlinks and mount points), walking up to
+    /// the nearest existing ancestor. Returns `0` when it can't be determined or
+    /// on unsupported platforms.
     fn get_free_disk_space(&self, path: &Path) -> u64 {
-        #[cfg(unix)]
-        {
-            use std::os::unix::ffi::OsStrExt;
-            let mut dir = path;
-            loop {
-                if let Ok(c) = std::ffi::CString::new(dir.as_os_str().as_bytes()) {
-                    // Apple's `statvfs` reports `f_bavail` through a 32-bit
-                    // `fsblkcnt_t`, which rolls over for volumes with more than
-                    // ~4 TB free — Darwin does not scale `f_frsize` to compensate
-                    // (rust-lang/libc; Apple Libc). `statfs` exposes a 64-bit
-                    // `f_bavail`, so use it on Apple targets and `statvfs` elsewhere.
-                    #[cfg(target_vendor = "apple")]
-                    {
-                        let mut stat = std::mem::MaybeUninit::<libc::statfs>::uninit();
-                        // SAFETY: `c` is a valid NUL-terminated path and `stat` is
-                        // a correctly sized, writable `statfs` buffer.
-                        if unsafe { libc::statfs(c.as_ptr(), stat.as_mut_ptr()) } == 0 {
-                            let stat = unsafe { stat.assume_init() };
-                            // `f_bavail` is in units of `f_bsize` for `statfs`.
-                            #[allow(clippy::unnecessary_cast)]
-                            return stat.f_bavail as u64 * stat.f_bsize as u64;
-                        }
+        // Available bytes on the volume backing an existing `p`, or `None` if the
+        // query fails (e.g. `p` doesn't exist yet). Interior-NUL paths — which no
+        // real path has — return `None` so the caller walks up to a usable parent.
+        #[allow(clippy::unnecessary_cast)] // block-count/size widths vary per platform
+        fn available(p: &Path) -> Option<u64> {
+            #[cfg(unix)]
+            {
+                use std::os::unix::ffi::OsStrExt;
+                let c = std::ffi::CString::new(p.as_os_str().as_bytes()).ok()?;
+                // Apple's `statvfs` f_bavail is a 32-bit count that rolls over past
+                // ~4 TB free; `statfs` is 64-bit. Use `statfs` on Apple, `statvfs`
+                // elsewhere — both give bytes as `f_bavail * (block size)`.
+                #[cfg(target_vendor = "apple")]
+                {
+                    let mut s = std::mem::MaybeUninit::<libc::statfs>::uninit();
+                    // SAFETY: `c` is NUL-terminated; `s` is a writable buffer.
+                    if unsafe { libc::statfs(c.as_ptr(), s.as_mut_ptr()) } != 0 {
+                        return None;
                     }
-                    #[cfg(not(target_vendor = "apple"))]
-                    {
-                        let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
-                        // SAFETY: `c` is a valid NUL-terminated path and `stat` is
-                        // a correctly sized, writable `statvfs` buffer.
-                        if unsafe { libc::statvfs(c.as_ptr(), stat.as_mut_ptr()) } == 0 {
-                            let stat = unsafe { stat.assume_init() };
-                            // `f_bavail` is in units of `f_frsize` for `statvfs`;
-                            // widths differ per platform, so cast both.
-                            #[allow(clippy::unnecessary_cast)]
-                            return stat.f_bavail as u64 * stat.f_frsize as u64;
-                        }
+                    let s = unsafe { s.assume_init() };
+                    Some(s.f_bavail as u64 * s.f_bsize as u64)
+                }
+                #[cfg(not(target_vendor = "apple"))]
+                {
+                    let mut s = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+                    // SAFETY: `c` is NUL-terminated; `s` is a writable buffer.
+                    if unsafe { libc::statvfs(c.as_ptr(), s.as_mut_ptr()) } != 0 {
+                        return None;
                     }
+                    let s = unsafe { s.assume_init() };
+                    Some(s.f_bavail as u64 * s.f_frsize as u64)
                 }
-                match dir.parent() {
-                    Some(parent) => dir = parent,
-                    None => return 0,
+            }
+            #[cfg(windows)]
+            {
+                use std::os::windows::ffi::OsStrExt;
+                // kernel32!GetDiskFreeSpaceExW; lpFreeBytesAvailableToCaller is
+                // 64-bit bytes available to the caller.
+                #[link(name = "kernel32")]
+                unsafe extern "system" {
+                    fn GetDiskFreeSpaceExW(
+                        lpDirectoryName: *const u16,
+                        lpFreeBytesAvailableToCaller: *mut u64,
+                        lpTotalNumberOfBytes: *mut u64,
+                        lpTotalNumberOfFreeBytes: *mut u64,
+                    ) -> i32;
                 }
+                let mut wide: Vec<u16> = p.as_os_str().encode_wide().collect();
+                if wide.contains(&0) {
+                    return None; // a NUL would terminate the path early
+                }
+                wide.push(0);
+                let mut avail = 0u64;
+                // SAFETY: `wide` is NUL-terminated; the out-params are writable u64
+                // slots; `avail` is read only on success.
+                (unsafe {
+                    GetDiskFreeSpaceExW(
+                        wide.as_ptr(),
+                        &mut avail,
+                        std::ptr::null_mut(),
+                        std::ptr::null_mut(),
+                    )
+                } != 0)
+                    .then_some(avail)
+            }
+            #[cfg(not(any(unix, windows)))]
+            {
+                let _ = p;
+                None
             }
         }
-        #[cfg(windows)]
-        {
-            use std::os::windows::ffi::OsStrExt;
-            // kernel32!GetDiskFreeSpaceExW — no new dependency, mirrors the raw
-            // `libc::statvfs` FFI above. `lpFreeBytesAvailableToCaller` is already
-            // 64-bit bytes available to the caller (honouring quotas), so there is
-            // no block-count multiplication and no per-platform width concern.
-            #[link(name = "kernel32")]
-            unsafe extern "system" {
-                fn GetDiskFreeSpaceExW(
-                    lpDirectoryName: *const u16,
-                    lpFreeBytesAvailableToCaller: *mut u64,
-                    lpTotalNumberOfBytes: *mut u64,
-                    lpTotalNumberOfFreeBytes: *mut u64,
-                ) -> i32;
+
+        let mut dir = path;
+        loop {
+            if let Some(bytes) = available(dir) {
+                return bytes;
             }
-            let mut dir = path;
-            loop {
-                let mut wide: Vec<u16> = dir.as_os_str().encode_wide().collect();
-                // Reject an interior NUL (impossible in a real path): a premature
-                // wide-string terminator would silently query the wrong path.
-                // Skip to the parent, mirroring `CString::new` on Unix.
-                if !wide.contains(&0) {
-                    wide.push(0);
-                    let mut avail: u64 = 0;
-                    // SAFETY: `wide` is a valid NUL-terminated UTF-16 path; the
-                    // three out-params are writable `u64` (`ULARGE_INTEGER`) slots,
-                    // and `avail` is read only when the call reports success.
-                    if unsafe {
-                        GetDiskFreeSpaceExW(
-                            wide.as_ptr(),
-                            &mut avail,
-                            std::ptr::null_mut(),
-                            std::ptr::null_mut(),
-                        )
-                    } != 0
-                    {
-                        return avail;
-                    }
-                }
-                match dir.parent() {
-                    Some(parent) => dir = parent,
-                    None => return 0,
-                }
+            match dir.parent() {
+                Some(parent) => dir = parent,
+                None => return 0,
             }
-        }
-        #[cfg(not(any(unix, windows)))]
-        {
-            let _ = path;
-            0
         }
     }
 

--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -112,8 +112,9 @@ pub trait BackupDelegate: Send + Sync {
 /// Default [`BackupDelegate`] that reads/writes to the local filesystem via `tokio::fs`.
 ///
 /// [`get_free_disk_space`](BackupDelegate::get_free_disk_space) reports real free
-/// space via `statfs`/`statvfs` on Unix and `GetDiskFreeSpaceExW` on Windows; on
-/// other platforms it returns `0` (override if you need disk-space reporting there).
+/// space via `statfs`/`statvfs` on Unix and `GetDiskFreeSpaceExW` on Windows;
+/// platforms without an OS query report a large constant (a backup host is assumed
+/// to have room). Override for exact accounting.
 ///
 /// Native-only: `tokio::fs` doesn't compile on `wasm32-unknown-unknown`.
 /// Wasm consumers must implement their own [`BackupDelegate`] backed by
@@ -124,11 +125,15 @@ pub struct FsBackupDelegate;
 
 #[cfg(not(target_arch = "wasm32"))]
 impl BackupDelegate for FsBackupDelegate {
-    /// Free space in bytes available to an unprivileged user on the volume
-    /// backing `path` (resolved through symlinks and mount points), walking up to
-    /// the nearest existing ancestor. Returns `0` when it can't be determined or
-    /// on unsupported platforms.
+    /// Free space in bytes available to an unprivileged user on the volume backing
+    /// `path` (resolved through symlinks and mount points), walking up to the
+    /// nearest existing ancestor. Where the OS can't be queried it reports a large
+    /// constant instead of `0`, since a backup host is assumed to have room.
     fn get_free_disk_space(&self, path: &Path) -> u64 {
+        // Returned when the OS can't tell us — no query on this platform, or the
+        // path resolved to nothing: assume the host has room rather than `0`.
+        const ASSUMED_FREE: u64 = 1 << 50; // ~1 PiB, far above any device backup
+
         // Available bytes on the volume backing an existing `p`, or `None` if the
         // query fails (e.g. `p` doesn't exist yet). Interior-NUL paths — which no
         // real path has — return `None` so the caller walks up to a usable parent.
@@ -208,7 +213,7 @@ impl BackupDelegate for FsBackupDelegate {
             }
             match dir.parent() {
                 Some(parent) => dir = parent,
-                None => return 0,
+                None => return ASSUMED_FREE,
             }
         }
     }


### PR DESCRIPTION
## Problem

`FsBackupDelegate::get_free_disk_space` returns a hardcoded `0`:

```rust
fn get_free_disk_space(&self, _path: &Path) -> u64 { 0 }
```

During a backup the device asks the host how much free space it has and **aborts
the whole backup with `ErrorCode 105`** ("Insufficient free disk space") when the
value is too small. So the *ready-made* delegate can never actually complete a
backup out of the box — every caller has to wrap `FsBackupDelegate` just to
override this one method.

```
device backup error 105: Insufficient free disk space on drive to back up
(MBErrorDomain/105)
```

## Fix

Report real available space where the OS exposes it, using only the existing
`libc` dependency plus a small `kernel32` FFI — **no new dependency**. The
requested path may not exist yet when first queried (the backup dir is created
lazily), so the lookup walks up to the nearest existing ancestor; a
soon-to-be-created subdir lands on that ancestor's volume, so its free space is
the right figure.

- **Linux / other Unix:** `statvfs` → `f_bavail * f_frsize`.
- **macOS / Apple:** `statfs` → `f_bavail * f_bsize`. Apple's `statvfs` reports
  `f_bavail` through a **32-bit** `fsblkcnt_t` and rolls over for volumes with
  more than ~4 TB free (Darwin doesn't scale `f_frsize` to compensate — cf.
  [cpython#87804](https://github.com/python/cpython/issues/87804),
  [borg#4289](https://github.com/borgbackup/borg/issues/4289)), which would
  re-trigger ErrorCode 105 on large backup targets. `statfs` exposes a 64-bit
  `f_bavail`, so it is used on Apple.
- **Windows:** `kernel32!GetDiskFreeSpaceExW` → `lpFreeBytesAvailableToCaller`
  (already 64-bit bytes; raw FFI, no new dependency).
- **Platforms with no free-space query (wasm, etc.):** report a large constant
  (~1 PiB) instead of `0`, since a backup host can be assumed to have room — `0`
  would make the device refuse the backup. Override for exact accounting.

A single `available(path) -> Option<u64>` helper isolates the per-platform
syscall; the walk-up loop is written once:

```rust
fn get_free_disk_space(&self, path: &Path) -> u64 {
    const ASSUMED_FREE: u64 = 1 << 50; // ~1 PiB — used where the OS can't be queried
    fn available(p: &Path) -> Option<u64> {
        #[cfg(unix)]    { /* statfs on Apple (64-bit), statvfs elsewhere */ }
        #[cfg(windows)] { /* GetDiskFreeSpaceExW -> lpFreeBytesAvailableToCaller */ }
        #[cfg(not(any(unix, windows)))] { None }
    }
    let mut dir = path;
    loop {
        if let Some(bytes) = available(dir) { return bytes; }
        match dir.parent() { Some(p) => dir = p, None => return ASSUMED_FREE }
    }
}
```

### Notes

- **Symlinks / mount points:** resolved by the OS calls themselves — `statvfs` /
  `statfs` / `GetDiskFreeSpaceExW` all report the volume that actually backs the
  path (where backup data lands), which is the figure the device wants.
- **Interior NUL in a path** (impossible for a real path): rejected, and the
  walk-up continues to the nearest usable ancestor — `CString::new` on Unix, an
  explicit check on Windows.
- **Why not a crate?** `fs2` / `fs4` both call `statvfs` uniformly with no Apple
  special-case, so they would reintroduce the macOS rollover above *and* add a
  dependency.

## Tests

Two unit tests (compiled on Unix & Windows): real free space is non-zero, and a
non-existent path still resolves via an existing ancestor.

```
test services::mobilebackup2::tests::fs_delegate_reports_real_free_space ... ok
test services::mobilebackup2::tests::fs_delegate_free_space_walks_up_to_existing_ancestor ... ok
```

`cargo fmt --check` / `cargo clippy` clean for `-p idevice --features mobilebackup2`.

---

Found while building a full encrypted backup with `FsBackupDelegate`; together
with #104 (DeviceLink path resolution) the stock delegate now drives a complete
backup unmodified on Linux, macOS, and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
