### PR TITLE
feature(mobilebackup2): add cancel callback

### DIFF
--- a/cpp/include/idevice++/mobilebackup2.hpp
+++ b/cpp/include/idevice++/mobilebackup2.hpp
@@ -50,6 +50,9 @@ struct BackupDelegateCallbacks {
     /// Check if a path is a directory
     std::function<bool(const std::string&)>                         is_dir;
 
+    /// Optional cancellation callback
+    std::function<bool()>                                           is_cancelled;
+
     /// Optional progress callback: bytes_done, bytes_total, overall_progress
     std::function<void(uint64_t, uint64_t, double)>                 on_progress;
 };

--- a/cpp/src/mobilebackup2.cpp
+++ b/cpp/src/mobilebackup2.cpp
@@ -143,6 +143,11 @@ extern "C" bool is_dir_trampoline(const char* path, void* ctx) {
     return false;
 }
 
+extern "C" bool is_cancelled_trampoline(void* ctx) {
+    auto& cbs = *static_cast<BackupDelegateCallbacks*>(ctx);
+    return cbs.is_cancelled ? cbs.is_cancelled() : false;
+}
+
 extern "C" void on_progress_trampoline(uint64_t bytes_done,
                                        uint64_t bytes_total,
                                        double   overall_progress,
@@ -167,6 +172,7 @@ Mobilebackup2BackupDelegateFFI make_ffi_delegate(BackupDelegateCallbacks& cbs) {
     d.copy                = copy_trampoline;
     d.exists              = exists_trampoline;
     d.is_dir              = is_dir_trampoline;
+    d.is_cancelled        = cbs.is_cancelled ? is_cancelled_trampoline : nullptr;
     d.on_progress         = cbs.on_progress ? on_progress_trampoline : nullptr;
     return d;
 }

--- a/ffi/src/mobilebackup2.rs
+++ b/ffi/src/mobilebackup2.rs
@@ -76,6 +76,9 @@ pub struct Mobilebackup2BackupDelegateFFI {
 
     pub is_dir: extern "C" fn(path: *const c_char, context: *mut c_void) -> bool,
 
+    /// Optional cancellation callback. May be NULL.
+    pub is_cancelled: Option<extern "C" fn(context: *mut c_void) -> bool>,
+
     /// Optional progress callback. May be NULL.
     pub on_progress: Option<
         extern "C" fn(
@@ -105,6 +108,10 @@ struct FfiFileWriter {
 impl Write for FfiFileWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let d = unsafe { &*self.delegate };
+        if is_cancelled(d) {
+            return Err(std::io::Error::other("operation cancelled"));
+        }
+
         let err = (d.write_chunk)(self.path_c.as_ptr(), buf.as_ptr(), buf.len(), d.context);
         if err.is_null() {
             Ok(buf.len())
@@ -148,8 +155,22 @@ fn ffi_err_to_idevice(err: *mut IdeviceFfiError) -> IdeviceError {
     IdeviceError::InternalError(msg)
 }
 
+fn cancelled_error() -> IdeviceError {
+    IdeviceError::InternalError("operation cancelled".to_string())
+}
+
+fn is_cancelled(delegate: &Mobilebackup2BackupDelegateFFI) -> bool {
+    delegate
+        .is_cancelled
+        .map(|cb| cb(delegate.context))
+        .unwrap_or(false)
+}
+
 impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
     fn get_free_disk_space(&self, path: &Path) -> u64 {
+        if is_cancelled(self) {
+            return 0;
+        }
         let c = path_to_cstring(path);
         (self.get_free_disk_space)(c.as_ptr(), self.context)
     }
@@ -159,6 +180,10 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
         path: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<Box<dyn Read + Send>, IdeviceError>> + Send + 'a>> {
         Box::pin(async move {
+            if is_cancelled(self) {
+                return Err(cancelled_error());
+            }
+
             let c = path_to_cstring(path);
             let mut data: *mut u8 = null_mut();
             let mut len: usize = 0;
@@ -181,6 +206,10 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
     ) -> Pin<Box<dyn Future<Output = Result<Box<dyn Write + Send>, IdeviceError>> + Send + 'a>>
     {
         Box::pin(async move {
+            if is_cancelled(self) {
+                return Err(cancelled_error());
+            }
+
             let c = path_to_cstring(path);
             let err = (self.create_file_write)(c.as_ptr(), self.context);
             if !err.is_null() {
@@ -198,6 +227,10 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
         path: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<(), IdeviceError>> + Send + 'a>> {
         Box::pin(async move {
+            if is_cancelled(self) {
+                return Err(cancelled_error());
+            }
+
             let c = path_to_cstring(path);
             let err = (self.create_dir_all)(c.as_ptr(), self.context);
             if err.is_null() {
@@ -213,6 +246,10 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
         path: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<(), IdeviceError>> + Send + 'a>> {
         Box::pin(async move {
+            if is_cancelled(self) {
+                return Err(cancelled_error());
+            }
+
             let c = path_to_cstring(path);
             let err = (self.remove)(c.as_ptr(), self.context);
             if err.is_null() {
@@ -229,6 +266,10 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
         to: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<(), IdeviceError>> + Send + 'a>> {
         Box::pin(async move {
+            if is_cancelled(self) {
+                return Err(cancelled_error());
+            }
+
             let cf = path_to_cstring(from);
             let ct = path_to_cstring(to);
             let err = (self.rename)(cf.as_ptr(), ct.as_ptr(), self.context);
@@ -246,6 +287,10 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
         dst: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<(), IdeviceError>> + Send + 'a>> {
         Box::pin(async move {
+            if is_cancelled(self) {
+                return Err(cancelled_error());
+            }
+
             let cs = path_to_cstring(src);
             let cd = path_to_cstring(dst);
             let err = (self.copy)(cs.as_ptr(), cd.as_ptr(), self.context);
@@ -259,6 +304,9 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
 
     fn exists<'a>(&'a self, path: &'a Path) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
         Box::pin(async move {
+            if is_cancelled(self) {
+                return false;
+            }
             let c = path_to_cstring(path);
             (self.exists)(c.as_ptr(), self.context)
         })
@@ -266,6 +314,9 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
 
     fn is_dir<'a>(&'a self, path: &'a Path) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
         Box::pin(async move {
+            if is_cancelled(self) {
+                return false;
+            }
             let c = path_to_cstring(path);
             (self.is_dir)(c.as_ptr(), self.context)
         })
@@ -278,10 +329,18 @@ impl BackupDelegate for Mobilebackup2BackupDelegateFFI {
         // The C delegate doesn't need list_dir - the library's FsBackupDelegate
         // handles it via tokio::fs. For FFI, return empty since this is only used
         // for DLContentsOfDirectory which is rare.
-        Box::pin(async { Ok(Vec::new()) })
+        Box::pin(async move {
+            if is_cancelled(self) {
+                return Err(cancelled_error());
+            }
+            Ok(Vec::new())
+        })
     }
 
     fn on_progress(&self, bytes_done: u64, bytes_total: u64, overall_progress: f64) {
+        if is_cancelled(self) {
+            return;
+        }
         if let Some(cb) = self.on_progress {
             cb(bytes_done, bytes_total, overall_progress, self.context);
         }


### PR DESCRIPTION
This PR adds a cancel callback for backups. This allows a developer to connect to it and grants the user to cancel the backup in progress cleanly.
This PR was assisted by Gemini, no agent (thanks for the free student subscription).