### PR TITLE
feature(mobilebackup2): full backup flag

### DIFF
--- a/tools/src/mobilebackup2.rs
+++ b/tools/src/mobilebackup2.rs
@@ -249,7 +249,8 @@ pub fn register() -> JkCommand {
                     JkArgument::new()
                         .with_help("Source identifier for the backup")
                         .required(true),
-                ),
+                )
+                .with_flag(JkFlag::new("full").with_help("Force a full backup from the device")),
         )
         .with_subcommand(
             "restore",
@@ -371,9 +372,17 @@ pub async fn main(arguments: &CollectedArguments, provider: Box<dyn IdeviceProvi
             let source = sub_args.next_argument::<String>();
             let source = source.as_deref();
 
+            let options = if sub_args.has_flag("full") {
+                let mut opts = plist::Dictionary::new();
+                opts.insert("ForceFullBackup".into(), plist::Value::Boolean(true));
+                Some(opts)
+            } else {
+                None
+            };
+
             println!("Starting backup...");
             match backup_client
-                .backup_from_path(Path::new(&dir), source, None, &delegate)
+                .backup_from_path(Path::new(&dir), source, options, &delegate)
                 .await
             {
                 Ok(Some(response)) => {


### PR DESCRIPTION
This PR adds the ForceFullBackup flag. It restricts the device by forcing it not to make a differential backup, and force a full one. I ran into issues sometimes, and I found that enabling this flag makes it easier for me.
This PR was slightly AI assisted with Gemini