### PR TITLE
fix(mobilebackup2): check Manifest.db

### DIFF
--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -1542,15 +1542,19 @@ impl MobileBackup2Client {
         Ok(())
     }
 
-    /// Assert a complete backup dir structure exists (Info + Manifest + Status plists)
+    /// Assert a readable backup dir structure exists.
+    ///
+    /// `Info.plist` is host-side display metadata and is not required for
+    /// MobileBackup2 to read a modern backup. The files required for modern
+    /// backup readability are the status plist plus the manifest plist/database.
     async fn assert_backup_exists(
         backup_root: &Path,
         source: &str,
         delegate: &dyn BackupDelegate,
     ) -> Result<(), IdeviceError> {
         let device_dir = backup_root.join(source);
-        if delegate.exists(&device_dir.join("Info.plist")).await
-            && delegate.exists(&device_dir.join("Manifest.plist")).await
+        if delegate.exists(&device_dir.join("Manifest.plist")).await
+            && delegate.exists(&device_dir.join("Manifest.db")).await
             && delegate.exists(&device_dir.join("Status.plist")).await
         {
             Ok(())


### PR DESCRIPTION
This PR fixes an issue with the backup checks. The Info.plist is in fact not required to have a backup that works, it's some simple metadata to better reference it for a developer, but it's not a necessity.
What is often found however is a Manifest.db (except maybe for older devices, but I'm not sure), which I added. I saw some old backup I made from some iPhone 4S that didn't have these, but maybe it changed since then. I'll make another PR if it changes.
This was not AI-assisted.