### PR TITLE
feat(mobilebackup2): forward restore progress through on_progress

### DIFF
--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -235,9 +235,15 @@ impl BackupDelegate for FsBackupDelegate {
         path: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<Box<dyn Read + Send>, IdeviceError>> + Send + 'a>> {
         Box::pin(async move {
-            let file = tokio::fs::File::open(path)
-                .await
-                .map_err(|e| IdeviceError::InternalError(e.to_string()))?;
+            // Missing files must surface as NotFound: the DL loop reports them
+            // to the device as ENOENT, which is how "no previous backup" reads.
+            let file = tokio::fs::File::open(path).await.map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    IdeviceError::NotFound
+                } else {
+                    IdeviceError::InternalError(e.to_string())
+                }
+            })?;
             let std_file = file.into_std().await;
             Ok(Box::new(std_file) as Box<dyn Read + Send>)
         })
@@ -1281,9 +1287,15 @@ impl MobileBackup2Client {
         let mut f = match delegate.open_file_read(&full).await {
             Ok(f) => f,
             Err(e) => {
+                // Only a genuinely missing file is ENOENT; any other open failure
+                // (I/O, corruption) must not tell the device the file is absent.
+                let code = match e {
+                    IdeviceError::NotFound => DEV_ERR_ENOENT,
+                    _ => DEV_ERR_GENERIC,
+                };
                 let desc = e.to_string();
                 self.send_file_error(&desc).await?;
-                return Ok(Some((DEV_ERR_ENOENT, desc)));
+                return Ok(Some((code, desc)));
             }
         };
         let mut buf = [0u8; 32768];

--- a/idevice/src/services/mobilebackup2.rs
+++ b/idevice/src/services/mobilebackup2.rs
@@ -120,6 +120,8 @@ pub trait BackupDelegate: Send + Sync {
     fn on_file_received(&self, _path: &str, _file_count: u32) {}
 
     /// Called periodically during file transfer with byte-level progress.
+    /// A `DownloadFiles` batch fires once with only the device percentage
+    /// (both byte fields 0) — that is how restore progress arrives.
     ///
     /// - `bytes_done`: total bytes transferred so far in this upload batch
     /// - `bytes_total`: total expected bytes for this batch (0 if unknown)
@@ -1131,6 +1133,9 @@ impl MobileBackup2Client {
 
             match tag.as_str() {
                 "DLMessageDownloadFiles" => {
+                    // The send path tracks no byte counts (idevicebackup2 parity);
+                    // report the device percentage parsed from this message.
+                    delegate.on_progress(0, 0, overall_progress);
                     self.handle_download_files(&value, host_dir, delegate)
                         .await?;
                 }


### PR DESCRIPTION
`process_dl_loop` already parses the device's overall percentage out of the DL messages that carry it (`DownloadFiles`/`Move*`/`Remove*` at array index 3, `UploadFiles` at index 2), but only the upload path forwards it to the delegate. During a restore the delegate therefore never receives a progress frame, so consumers have nothing to display.

This reports the parsed percentage in the `DLMessageDownloadFiles` branch, right before `handle_download_files` — the same spot where idevicebackup2 applies it (`mb2_set_overall_progress_from_message` runs in the message loop before `mb2_handle_send_files`). The send path tracks no byte counts, also matching idevicebackup2, so the byte fields stay `0`, which the `on_progress` doc already defines as "not reported".

No API change: the trait signature and its default no-op are untouched. Backups hit `DownloadFiles` too (the device fetches `Status.plist`/`Manifest.db` from the host) and now get the same percentage-only frames; byte-accumulating consumers ignore them by contract.

Verified with a Wi-Fi restore to a physical iPhone: the delegate now receives the device-reported percentage during the transfer. `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.
