### PR TITLE
feat(hid): add multitouch support

### DIFF
--- a/idevice/src/services/core_device/errors.rs
+++ b/idevice/src/services/core_device/errors.rs
@@ -24,6 +24,22 @@ pub enum CoreDeviceError {
     /// decode.
     #[error("media negotiation blob error: {0}")]
     Negotiation(String),
+
+    /// A touchscreen report contained more contacts than the device supports.
+    #[error("touchscreen report has {0} contacts; at most 5 are supported")]
+    TooManyTouchscreenContacts(usize),
+
+    /// A touchscreen contact identity was outside the supported range.
+    #[error("touchscreen contact identity {0} is outside 0..5")]
+    InvalidTouchscreenContactIdentity(u8),
+
+    /// A touchscreen report used the same contact identity more than once.
+    #[error("touchscreen contact identity {0} is duplicated")]
+    DuplicateTouchscreenContactIdentity(u8),
+
+    /// A multi-touch tap was requested without any contact positions.
+    #[error("multi-touch tap requires at least one contact")]
+    NoTouchscreenContacts,
 }
 
 impl CoreDeviceError {
@@ -33,6 +49,10 @@ impl CoreDeviceError {
             Self::MissingField(_) => 2,
             Self::MalformedField(_) => 3,
             Self::Negotiation(_) => 4,
+            Self::TooManyTouchscreenContacts(_) => 5,
+            Self::InvalidTouchscreenContactIdentity(_) => 6,
+            Self::DuplicateTouchscreenContactIdentity(_) => 7,
+            Self::NoTouchscreenContacts => 8,
         }
     }
 }

--- a/idevice/src/services/core_device/hid.rs
+++ b/idevice/src/services/core_device/hid.rs
@@ -125,9 +125,29 @@ pub const DIGITIZER_REPORT_ID: u8 = 0x13;
 pub const TOUCHSCREEN_REPORT_ID: u8 = 0x09;
 pub const TOUCHSCREEN_STATE_CONTACT: u8 = 0xC2;
 pub const TOUCHSCREEN_STATE_RELEASE: u8 = 0x02;
+/// Maximum number of contacts in one `mainTouchscreen` report.
+pub const TOUCHSCREEN_CONTACT_COUNT_MAXIMUM: u8 = 5;
 
 pub const DIGITIZER_SURFACE_MAIN_TOUCHSCREEN: u64 = 257;
 pub const DIGITIZER_SURFACE_TOUCHSCREEN_GESTURE: u64 = 1281;
+
+const TOUCHSCREEN_REPORT_SIZE: usize = 58;
+const TOUCHSCREEN_CONTACTS_OFFSET: usize = 3;
+const TOUCHSCREEN_CONTACT_SIZE: usize = 5;
+
+/// One contact in a `mainTouchscreen` HID report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TouchscreenContact {
+    /// Stable identity for the lifetime of this contact. Valid values are 0..5.
+    pub identity: u8,
+    /// Whether the contact is touching and in range. A release keeps the same
+    /// identity and coordinates with this set to `false`.
+    pub touching: bool,
+    /// Horizontal position in the touchscreen's normalized 16-bit space.
+    pub x: u16,
+    /// Vertical position in the touchscreen's normalized 16-bit space.
+    pub y: u16,
+}
 
 /// A 48-bit monotonic timestamp for HID reports. The gesture recognizer only
 /// cares about monotonicity and inter-frame deltas, so wall-clock nanoseconds
@@ -166,16 +186,82 @@ pub fn build_digitizer_report(x: i32, y: i32, timestamp: Option<u64>) -> Vec<u8>
 ///
 /// Layout: `[0x09 0x01 0x05 state][x:u16 LE][y:u16 LE][32×00][02 00 00 00][ts:6 LE][8×00]`.
 pub fn build_touchscreen_report(state: u8, x: u16, y: u16, timestamp: Option<u64>) -> Vec<u8> {
-    let ts = timestamp.unwrap_or_else(default_timestamp) & ((1u64 << 48) - 1);
-    let mut r = Vec::with_capacity(58);
-    r.extend_from_slice(&[TOUCHSCREEN_REPORT_ID, 0x01, 0x05, state]);
-    r.extend_from_slice(&x.to_le_bytes());
-    r.extend_from_slice(&y.to_le_bytes());
-    r.extend_from_slice(&[0u8; 32]);
-    r.extend_from_slice(&[0x02, 0x00, 0x00, 0x00]);
-    r.extend_from_slice(&ts.to_le_bytes()[..6]);
-    r.extend_from_slice(&[0u8; 8]);
+    let mut r = new_touchscreen_report(1, timestamp);
+    write_touchscreen_contact(&mut r, 0, state, x, y);
     r
+}
+
+/// Build a 58-byte `mainTouchscreen` report containing up to five contacts.
+///
+/// Every active contact must be included in each frame. To lift a contact,
+/// include it once more with [`TouchscreenContact::touching`] set to `false`
+/// and the same identity used by its active frames.
+pub fn build_multitouch_report(
+    contacts: &[TouchscreenContact],
+    timestamp: Option<u64>,
+) -> Result<Vec<u8>, CoreDeviceError> {
+    if contacts.len() > TOUCHSCREEN_CONTACT_COUNT_MAXIMUM as usize {
+        return Err(CoreDeviceError::TooManyTouchscreenContacts(contacts.len()));
+    }
+    for (index, contact) in contacts.iter().enumerate() {
+        if contact.identity >= TOUCHSCREEN_CONTACT_COUNT_MAXIMUM {
+            return Err(CoreDeviceError::InvalidTouchscreenContactIdentity(
+                contact.identity,
+            ));
+        }
+        if contacts[..index]
+            .iter()
+            .any(|other| other.identity == contact.identity)
+        {
+            return Err(CoreDeviceError::DuplicateTouchscreenContactIdentity(
+                contact.identity,
+            ));
+        }
+    }
+
+    let mut r = new_touchscreen_report(contacts.len() as u8, timestamp);
+    for (slot, contact) in contacts.iter().enumerate() {
+        let state = (if contact.touching { 0xC0 } else { 0 }) | contact.identity;
+        write_touchscreen_contact(&mut r, slot, state, contact.x, contact.y);
+    }
+    Ok(r)
+}
+
+fn multitap_contacts(positions: &[(u16, u16)]) -> Result<Vec<TouchscreenContact>, CoreDeviceError> {
+    if positions.is_empty() {
+        return Err(CoreDeviceError::NoTouchscreenContacts);
+    }
+    if positions.len() > TOUCHSCREEN_CONTACT_COUNT_MAXIMUM as usize {
+        return Err(CoreDeviceError::TooManyTouchscreenContacts(positions.len()));
+    }
+    Ok(positions
+        .iter()
+        .enumerate()
+        .map(|(identity, &(x, y))| TouchscreenContact {
+            identity: identity as u8,
+            touching: true,
+            x,
+            y,
+        })
+        .collect())
+}
+
+fn new_touchscreen_report(contact_count: u8, timestamp: Option<u64>) -> Vec<u8> {
+    let ts = timestamp.unwrap_or_else(default_timestamp) & ((1u64 << 48) - 1);
+    let mut r = vec![0; TOUCHSCREEN_REPORT_SIZE];
+    r[0] = TOUCHSCREEN_REPORT_ID;
+    r[1] = contact_count;
+    r[2] = TOUCHSCREEN_CONTACT_COUNT_MAXIMUM;
+    r[40..44].copy_from_slice(&[0x02, 0x00, 0x00, 0x00]);
+    r[44..50].copy_from_slice(&ts.to_le_bytes()[..6]);
+    r
+}
+
+fn write_touchscreen_contact(report: &mut [u8], slot: usize, state: u8, x: u16, y: u16) {
+    let offset = TOUCHSCREEN_CONTACTS_OFFSET + slot * TOUCHSCREEN_CONTACT_SIZE;
+    report[offset] = state;
+    report[offset + 1..offset + 3].copy_from_slice(&x.to_le_bytes());
+    report[offset + 3..offset + 5].copy_from_slice(&y.to_le_bytes());
 }
 
 /// Generic Indigo HID events.
@@ -505,6 +591,33 @@ impl<R: ReadWrite> UniversalHidServiceClient<R> {
         .await
     }
 
+    /// Send one `mainTouchscreen` report containing up to five contacts.
+    pub async fn send_multitouch(
+        &mut self,
+        contacts: &[TouchscreenContact],
+        timestamp: Option<u64>,
+    ) -> Result<(), IdeviceError> {
+        let report = build_multitouch_report(contacts, timestamp)?;
+        self.send_report(DIGITIZER_SURFACE_MAIN_TOUCHSCREEN, report)
+            .await
+    }
+
+    /// Tap one to five touchscreen positions in a single multi-contact frame.
+    ///
+    /// Contact identities are assigned in slice order. This method sends the
+    /// matching release frame before returning; use
+    /// [`send_multitouch`](Self::send_multitouch) directly for gestures that
+    /// need movement or independently timed contacts.
+    pub async fn multi_tap(&mut self, positions: &[(u16, u16)]) -> Result<(), IdeviceError> {
+        let mut contacts = multitap_contacts(positions)?;
+        self.send_multitouch(&contacts, None).await?;
+        crate::time::sleep(std::time::Duration::from_millis(50)).await;
+        contacts
+            .iter_mut()
+            .for_each(|contact| contact.touching = false);
+        self.send_multitouch(&contacts, None).await
+    }
+
     /// A tap on the touchscreen: one contact sample, a short hold, then a
     /// release at the same point.
     pub async fn tap(&mut self, x: u16, y: u16) -> Result<(), IdeviceError> {
@@ -582,5 +695,100 @@ mod tests {
         // A timestamp above 48 bits must be masked, not overflow the 6-byte field.
         let r = build_digitizer_report(0, 0, Some(u64::MAX));
         assert_eq!(&r[11..17], &[0xFF; 6]);
+    }
+
+    #[test]
+    fn multitouch_report_layout() {
+        let r = build_multitouch_report(
+            &[
+                TouchscreenContact {
+                    identity: 2,
+                    touching: true,
+                    x: 0x1234,
+                    y: 0x5678,
+                },
+                TouchscreenContact {
+                    identity: 3,
+                    touching: false,
+                    x: 0x9ABC,
+                    y: 0xDEF0,
+                },
+            ],
+            Some(0x0102030405),
+        )
+        .unwrap();
+
+        assert_eq!(r.len(), 58);
+        assert_eq!(&r[..3], &[0x09, 0x02, 0x05]);
+        assert_eq!(&r[3..8], &[0xC2, 0x34, 0x12, 0x78, 0x56]);
+        assert_eq!(&r[8..13], &[0x03, 0xBC, 0x9A, 0xF0, 0xDE]);
+        assert_eq!(&r[13..40], &[0; 27]);
+        assert_eq!(&r[40..44], &[0x02, 0x00, 0x00, 0x00]);
+        assert_eq!(&r[44..50], &0x0102030405u64.to_le_bytes()[..6]);
+        assert_eq!(&r[50..], &[0; 8]);
+    }
+
+    #[test]
+    fn multitouch_report_accepts_five_contacts() {
+        let contacts = [0, 1, 2, 3, 4].map(|identity| TouchscreenContact {
+            identity,
+            touching: true,
+            x: identity as u16,
+            y: identity as u16,
+        });
+        let r = build_multitouch_report(&contacts, Some(0)).unwrap();
+        assert_eq!(&r[..3], &[TOUCHSCREEN_REPORT_ID, 5, 5]);
+        assert_eq!(r[23], 0xC4);
+    }
+
+    #[test]
+    fn multitouch_report_accepts_an_empty_frame() {
+        let r = build_multitouch_report(&[], Some(0)).unwrap();
+        assert_eq!(&r[..3], &[TOUCHSCREEN_REPORT_ID, 0, 5]);
+        assert_eq!(&r[3..40], &[0; 37]);
+    }
+
+    #[test]
+    fn multitouch_report_validates_contacts() {
+        let contact = TouchscreenContact {
+            identity: 1,
+            touching: true,
+            x: 0,
+            y: 0,
+        };
+        assert!(matches!(
+            build_multitouch_report(&[contact; 6], None),
+            Err(CoreDeviceError::TooManyTouchscreenContacts(6))
+        ));
+        assert!(matches!(
+            build_multitouch_report(&[contact, contact], None),
+            Err(CoreDeviceError::DuplicateTouchscreenContactIdentity(1))
+        ));
+        assert!(matches!(
+            build_multitouch_report(
+                &[TouchscreenContact {
+                    identity: 5,
+                    ..contact
+                }],
+                None
+            ),
+            Err(CoreDeviceError::InvalidTouchscreenContactIdentity(5))
+        ));
+    }
+
+    #[test]
+    fn multitouch_tap_validates_positions_before_io() {
+        assert!(matches!(
+            multitap_contacts(&[]),
+            Err(CoreDeviceError::NoTouchscreenContacts)
+        ));
+        assert!(matches!(
+            multitap_contacts(&[(0, 0); 6]),
+            Err(CoreDeviceError::TooManyTouchscreenContacts(6))
+        ));
+        let contacts = multitap_contacts(&[(10, 20), (30, 40)]).unwrap();
+        assert_eq!(contacts[0].identity, 0);
+        assert_eq!(contacts[1].identity, 1);
+        assert!(contacts.iter().all(|contact| contact.touching));
     }
 }

--- a/tools/src/hid.rs
+++ b/tools/src/hid.rs
@@ -41,6 +41,61 @@ pub fn register() -> JkCommand {
                 .with_argument(JkArgument::new().with_help("Y (0-65535)").required(true)),
         )
         .with_subcommand(
+            "multi-tap",
+            JkCommand::new()
+                .help("Tap two to five touchscreen positions in one HID report")
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("first X (0-65535)")
+                        .required(true),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("first Y (0-65535)")
+                        .required(true),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("second X (0-65535)")
+                        .required(true),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("second Y (0-65535)")
+                        .required(true),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("optional third X (0-65535)")
+                        .required(false),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("optional third Y (0-65535)")
+                        .required(false),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("optional fourth X (0-65535)")
+                        .required(false),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("optional fourth Y (0-65535)")
+                        .required(false),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("optional fifth X (0-65535)")
+                        .required(false),
+                )
+                .with_argument(
+                    JkArgument::new()
+                        .with_help("optional fifth Y (0-65535)")
+                        .required(false),
+                ),
+        )
+        .with_subcommand(
             "drag",
             JkCommand::new()
                 .help(
@@ -164,6 +219,36 @@ pub async fn main(arguments: &CollectedArguments, provider: Box<dyn IdeviceProvi
                 Box::pin(async move {
                     hid.tap(x, y).await.expect("tap failed");
                     eprintln!("tapped ({x}, {y})");
+                })
+            })
+            .await;
+        }
+        "multi-tap" => {
+            let x1 = parse_arg::<u16>(&mut sub_args, "first X");
+            let y1 = parse_arg::<u16>(&mut sub_args, "first Y");
+            let x2 = parse_arg::<u16>(&mut sub_args, "second X");
+            let y2 = parse_arg::<u16>(&mut sub_args, "second Y");
+            let mut positions = vec![(x1, y1), (x2, y2)];
+            let mut optional_coordinates = Vec::new();
+            while let Some(value) = sub_args.next_argument::<String>() {
+                optional_coordinates.push(value);
+            }
+            match parse_touchscreen_positions(optional_coordinates) {
+                Ok(optional_positions) => positions.extend(optional_positions),
+                Err(error) => {
+                    eprintln!("{error}");
+                    return;
+                }
+            }
+            with_touch(&mut adapter, &mut handshake, |hid| {
+                Box::pin(async move {
+                    hid.multi_tap(&positions)
+                        .await
+                        .expect("multi-touch tap failed");
+                    eprintln!(
+                        "sent multi-touch tap report for {} contact(s)",
+                        positions.len()
+                    );
                 })
             })
             .await;
@@ -572,4 +657,65 @@ async fn with_indigo_stream<F>(
 fn parse_arg<T: jkcli::JkArgumentType>(args: &mut CollectedArguments, what: &str) -> T {
     args.next_argument()
         .unwrap_or_else(|| panic!("missing or invalid {what}, pass -h for help"))
+}
+
+fn parse_touchscreen_positions<I, S>(coordinates: I) -> Result<Vec<(u16, u16)>, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut coordinates = coordinates.into_iter();
+    let mut positions = Vec::new();
+
+    while let Some(raw_x) = coordinates.next() {
+        let raw_x = raw_x.as_ref();
+        let x = raw_x
+            .parse::<u16>()
+            .map_err(|_| format!("invalid optional touchscreen X `{raw_x}`; expected 0-65535"))?;
+
+        let raw_y = coordinates
+            .next()
+            .ok_or_else(|| "each optional touchscreen X must be followed by Y".to_string())?;
+        let raw_y = raw_y.as_ref();
+        let y = raw_y
+            .parse::<u16>()
+            .map_err(|_| format!("invalid optional touchscreen Y `{raw_y}`; expected 0-65535"))?;
+
+        positions.push((x, y));
+    }
+
+    Ok(positions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_touchscreen_positions;
+
+    #[test]
+    fn parses_optional_touchscreen_positions() {
+        assert_eq!(
+            parse_touchscreen_positions(["10", "20", "30", "40"]),
+            Ok(vec![(10, 20), (30, 40)])
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_optional_touchscreen_coordinates() {
+        assert_eq!(
+            parse_touchscreen_positions(["invalid", "20"]),
+            Err("invalid optional touchscreen X `invalid`; expected 0-65535".to_string())
+        );
+        assert_eq!(
+            parse_touchscreen_positions(["10", "65536"]),
+            Err("invalid optional touchscreen Y `65536`; expected 0-65535".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_unpaired_optional_touchscreen_coordinate() {
+        assert_eq!(
+            parse_touchscreen_positions(["10"]),
+            Err("each optional touchscreen X must be followed by Y".to_string())
+        );
+    }
 }


### PR DESCRIPTION
Add support for sending two to five simultaneous touchscreen contacts through the CoreDevice HID service.

This PR was developed with the assistance of GPT-5.6 and tested on iPhone 13 Pro Max running iOS 27.0.

- Add encoding for up to five contacts in a `mainTouchscreen` HID report
- Add APIs for sending multitouch frames and simultaneous taps
- Add the `idevice hid multi-tap` CLI command
- Validate contact count, identity, duplicate contacts, and coordinate input

Usage: 

```shell
idevice hid multi-tap X1 Y1 X2 Y2 [X3 Y3] [X4 Y4] [X5 Y5]
```