### PR TITLE
feat(xctest): support runner environment overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ To wait for WDA and expose localhost bridge URLs for HTTP and MJPEG:
 idevice-tools --udid <device-udid> xctest --bridge io.github.kor1k1.WebDriverAgentRunner.xctrunner
 ```
 
+Pass environment variables to the XCTest runner as comma-separated
+`KEY=VALUE` pairs. When bridging WDA, `USE_PORT` and `MJPEG_SERVER_PORT` also
+select the device-side endpoints used for readiness checks and forwarding:
+
+```bash
+idevice-tools --udid <device-udid> xctest --bridge --env 'USE_PORT=8200,MJPEG_SERVER_PORT=9200' io.github.kor1k1.WebDriverAgentRunner.xctrunner
+```
+
+Escape commas inside values as `\,` and backslashes as `\\`.
+
 The current `wda` support is intentionally a bootstrap layer for readiness
 checks and session startup, rather than a complete long-lived WebDriver
 client.

--- a/idevice/src/services/dvt/errors.rs
+++ b/idevice/src/services/dvt/errors.rs
@@ -12,6 +12,8 @@ pub enum DvtError {
     UnknownChannel(u32),
     #[error("disable memory limit failed")]
     DisableMemoryLimitFailed,
+    #[error("invalid XCTest runner environment: {0}")]
+    InvalidXCTestRunnerEnvironment(String),
 }
 
 impl DvtError {
@@ -21,6 +23,7 @@ impl DvtError {
             Self::UnknownAuxValueType(_) => 2,
             Self::UnknownChannel(_) => 3,
             Self::DisableMemoryLimitFailed => 4,
+            Self::InvalidXCTestRunnerEnvironment(_) => 5,
         }
     }
 }

--- a/idevice/src/services/dvt/xctest/mod.rs
+++ b/idevice/src/services/dvt/xctest/mod.rs
@@ -33,6 +33,8 @@ use serde_json::Value as JsonValue;
 use tracing::{debug, warn};
 
 #[cfg(feature = "wda")]
+use crate::services::dvt::errors::DvtError;
+#[cfg(feature = "wda")]
 use crate::services::wda::{WdaClient, WdaPorts};
 #[cfg(feature = "wda")]
 use crate::services::wda_bridge::WdaBridge;
@@ -1909,6 +1911,46 @@ struct NoopXCTestListener;
 #[cfg(feature = "wda")]
 impl XCUITestListener for NoopXCTestListener {}
 
+#[cfg(feature = "wda")]
+fn wda_port_overrides_from_runner_environment(
+    runner_env: Option<&Dictionary>,
+) -> Result<Option<WdaPorts>, DvtError> {
+    let http = wda_port_from_runner_environment(runner_env, "USE_PORT")?;
+    let mjpeg = wda_port_from_runner_environment(runner_env, "MJPEG_SERVER_PORT")?;
+    if http.is_none() && mjpeg.is_none() {
+        return Ok(None);
+    }
+
+    let defaults = WdaPorts::default();
+    Ok(Some(WdaPorts {
+        http: http.unwrap_or(defaults.http),
+        mjpeg: mjpeg.unwrap_or(defaults.mjpeg),
+    }))
+}
+
+#[cfg(feature = "wda")]
+fn wda_port_from_runner_environment(
+    runner_env: Option<&Dictionary>,
+    key: &str,
+) -> Result<Option<u16>, DvtError> {
+    let Some(value) = runner_env.and_then(|env| env.get(key)) else {
+        return Ok(None);
+    };
+    let value = value.as_string().ok_or_else(|| {
+        DvtError::InvalidXCTestRunnerEnvironment(format!("{key} must be a non-zero 16-bit integer"))
+    })?;
+    let port = value
+        .parse::<u16>()
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| {
+            DvtError::InvalidXCTestRunnerEnvironment(format!(
+                "{key} must be a non-zero 16-bit integer, got {value:?}"
+            ))
+        })?;
+    Ok(Some(port))
+}
+
 impl std::fmt::Debug for XCUITestService {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("XCUITestService")
@@ -2037,15 +2079,19 @@ impl XCUITestService {
         cfg: TestConfig,
         readiness_timeout: std::time::Duration,
     ) -> Result<WdaRunHandle, IdeviceError> {
+        let port_overrides = wda_port_overrides_from_runner_environment(cfg.runner_env.as_ref())?;
         let provider = self.provider.clone();
-        let runner_cfg = cfg.clone();
+        let runner_cfg = cfg;
         let task = tokio::spawn(async move {
             let service = XCUITestService::new(provider);
             let mut listener = NoopXCTestListener;
             service.run(runner_cfg, &mut listener, None).await
         });
 
-        let wda = WdaClient::new(&*self.provider);
+        let wda = match port_overrides {
+            Some(ports) => WdaClient::new(&*self.provider).with_ports(ports),
+            None => WdaClient::new(&*self.provider),
+        };
         let deadline = std::time::Instant::now() + readiness_timeout;
         let poll_interval = std::time::Duration::from_millis(250);
 
@@ -2095,5 +2141,70 @@ impl XCUITestService {
         let runner = self.run_until_wda_ready(cfg, readiness_timeout).await?;
         let bridge = WdaBridge::start_with_ports(self.provider.clone(), runner.ports()).await?;
         Ok(WdaBridgedRunHandle { runner, bridge })
+    }
+}
+
+#[cfg(all(test, feature = "wda"))]
+mod tests {
+    use super::wda_port_overrides_from_runner_environment;
+    use crate::services::wda::WdaPorts;
+
+    #[test]
+    fn wda_ports_follow_runner_environment() {
+        let runner_env = crate::plist!(dict {
+            "USE_PORT": "8200",
+            "MJPEG_SERVER_PORT": "9200",
+        });
+
+        let ports = wda_port_overrides_from_runner_environment(Some(&runner_env))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(ports.http, 8200);
+        assert_eq!(ports.mjpeg, 9200);
+    }
+
+    #[test]
+    fn wda_ports_are_not_overridden_without_runner_environment() {
+        assert_eq!(
+            wda_port_overrides_from_runner_environment(None).unwrap(),
+            None
+        );
+
+        let unrelated_environment = crate::plist!(dict {
+            "LANG": "en_US",
+        });
+        assert_eq!(
+            wda_port_overrides_from_runner_environment(Some(&unrelated_environment)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn wda_port_override_preserves_the_other_client_default() {
+        let runner_env = crate::plist!(dict {
+            "USE_PORT": "8200",
+        });
+        let ports = wda_port_overrides_from_runner_environment(Some(&runner_env))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(ports.http, 8200);
+        assert_eq!(ports.mjpeg, WdaPorts::default().mjpeg);
+    }
+
+    #[test]
+    fn wda_ports_reject_invalid_runner_environment() {
+        for value in ["0", "65536", "not-a-port"] {
+            let runner_env = crate::plist!(dict {
+                "USE_PORT": value,
+            });
+            assert!(wda_port_overrides_from_runner_environment(Some(&runner_env)).is_err());
+        }
+
+        let runner_env = crate::plist!(dict {
+            "MJPEG_SERVER_PORT": 9200i64,
+        });
+        assert!(wda_port_overrides_from_runner_environment(Some(&runner_env)).is_err());
     }
 }

--- a/tests/src/xctest.rs
+++ b/tests/src/xctest.rs
@@ -20,17 +20,107 @@
 use std::{sync::Arc, time::Duration};
 
 use idevice::{
-    IdeviceService,
+    IdeviceError, IdeviceService,
     dvt::xctest::{TestConfig, XCUITestService},
     provider::IdeviceProvider,
-    services::{installation_proxy::InstallationProxyClient, wda::WdaClient},
+    services::{
+        installation_proxy::InstallationProxyClient,
+        wda::{WdaClient, WdaPorts},
+    },
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    time::{Instant, sleep, timeout},
 };
 
 use crate::run_test;
 
 const WDA_READINESS_TIMEOUT: Duration = Duration::from_secs(120);
+const BRIDGE_READINESS_TIMEOUT: Duration = Duration::from_secs(30);
+const BRIDGE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_HTTP_HEADER_SIZE: usize = 64 * 1024;
+const WDA_TEST_PORTS: WdaPorts = WdaPorts {
+    http: 8200,
+    mjpeg: 9200,
+};
 const SETTINGS_BUNDLE: &str = "com.apple.Preferences";
 const RUNNER_NAME_KEYWORDS: &[&str] = &["webdriveragent", "integrationapp", "xctrunner"];
+
+async fn read_bridge_response_head(port: u16, path: &str) -> Result<String, IdeviceError> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).await?;
+    let request =
+        format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).await?;
+
+    let mut response = Vec::new();
+    let head_end = timeout(BRIDGE_REQUEST_TIMEOUT, async {
+        let mut chunk = [0u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).await?;
+            if read == 0 {
+                return Err(IdeviceError::UnexpectedResponse(
+                    "bridge closed before returning HTTP headers".into(),
+                ));
+            }
+            response.extend_from_slice(&chunk[..read]);
+
+            if let Some(index) = response.windows(4).position(|window| window == b"\r\n\r\n") {
+                return Ok(index + 4);
+            }
+            if response.len() > MAX_HTTP_HEADER_SIZE {
+                return Err(IdeviceError::UnexpectedResponse(
+                    "bridge returned oversized HTTP headers".into(),
+                ));
+            }
+        }
+    })
+    .await
+    .map_err(|_| IdeviceError::Timeout)??;
+
+    response.truncate(head_end);
+    String::from_utf8(response).map_err(IdeviceError::from)
+}
+
+async fn wait_for_bridge_response_head(port: u16, path: &str) -> Result<String, IdeviceError> {
+    let deadline = Instant::now() + BRIDGE_READINESS_TIMEOUT;
+    loop {
+        match read_bridge_response_head(port, path).await {
+            Ok(response) => return Ok(response),
+            Err(_) if Instant::now() < deadline => sleep(Duration::from_millis(250)).await,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn verify_bridge_response(
+    response_head: &str,
+    expected_content_type: Option<&str>,
+) -> Result<(), IdeviceError> {
+    let status = response_head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|value| value.parse::<u16>().ok());
+    if !status.is_some_and(|status| (200..300).contains(&status)) {
+        return Err(IdeviceError::UnexpectedResponse(format!(
+            "bridge returned unsuccessful HTTP status: {:?}",
+            response_head.lines().next()
+        )));
+    }
+
+    if let Some(expected) = expected_content_type
+        && !response_head
+            .to_ascii_lowercase()
+            .contains(&expected.to_ascii_lowercase())
+    {
+        return Err(IdeviceError::UnexpectedResponse(format!(
+            "bridge response did not contain content type {expected:?}"
+        )));
+    }
+
+    Ok(())
+}
 
 /// Search installed apps for a bundle whose display name or bundle name
 /// contains one of the runner keywords (case-insensitive). Returns the
@@ -79,7 +169,7 @@ pub async fn run_tests(provider: Arc<dyn IdeviceProvider>, success: &mut u32, fa
     println!("  xctest: runner: {bundle_id}");
 
     // Build TestConfig from the installed runner
-    let cfg = {
+    let mut cfg = {
         let mut iproxy = match InstallationProxyClient::connect(&*provider).await {
             Ok(c) => c,
             Err(e) => {
@@ -98,12 +188,18 @@ pub async fn run_tests(provider: Arc<dyn IdeviceProvider>, success: &mut u32, fa
             }
         }
     };
+    let runner_env = cfg.runner_env.get_or_insert_default();
+    runner_env.insert("USE_PORT".into(), WDA_TEST_PORTS.http.to_string().into());
+    runner_env.insert(
+        "MJPEG_SERVER_PORT".into(),
+        WDA_TEST_PORTS.mjpeg.to_string().into(),
+    );
 
     let service = XCUITestService::new(provider.clone());
 
-    // Launch WDA and wait until it's reachable
+    // Launch WDA on non-default ports, wait until it's reachable, and start the bridge
     let handle = match service
-        .run_until_wda_ready(cfg, WDA_READINESS_TIMEOUT)
+        .run_until_wda_ready_with_bridge(cfg, WDA_READINESS_TIMEOUT)
         .await
     {
         Ok(h) => {
@@ -123,6 +219,30 @@ pub async fn run_tests(provider: Arc<dyn IdeviceProvider>, success: &mut u32, fa
             return;
         }
     };
+
+    run_test!("xctest: WDA custom device ports", success, failure, async {
+        let endpoints = handle.bridge().endpoints();
+        if handle.ports() == WDA_TEST_PORTS && endpoints.device_ports == WDA_TEST_PORTS {
+            Ok(())
+        } else {
+            Err(idevice::IdeviceError::UnexpectedResponse(format!(
+                "expected device ports {:?}, got runner {:?} and bridge {:?}",
+                WDA_TEST_PORTS,
+                handle.ports(),
+                endpoints.device_ports
+            )))
+        }
+    });
+
+    let local_ports = handle.bridge().endpoints().local_ports;
+    run_test!("xctest: WDA HTTP bridge status", success, failure, async {
+        let response = wait_for_bridge_response_head(local_ports.http, "/status").await?;
+        verify_bridge_response(&response, Some("application/json"))
+    });
+    run_test!("xctest: WDA MJPEG bridge stream", success, failure, async {
+        let response = wait_for_bridge_response_head(local_ports.mjpeg, "/").await?;
+        verify_bridge_response(&response, Some("multipart/x-mixed-replace"))
+    });
 
     let mut wda = WdaClient::new(&*provider).with_ports(handle.ports());
 

--- a/tools/src/xctest.rs
+++ b/tools/src/xctest.rs
@@ -11,10 +11,14 @@ use std::{sync::Arc, time::Duration};
 use idevice::{
     IdeviceError, IdeviceService,
     provider::IdeviceProvider,
-    services::dvt::xctest::{TestConfig, XCUITestService, listener::XCUITestListener},
+    services::dvt::{
+        errors::DvtError,
+        xctest::{TestConfig, XCUITestService, listener::XCUITestListener},
+    },
     services::installation_proxy::InstallationProxyClient,
 };
 use jkcli::{CollectedArguments, JkArgument, JkCommand, JkFlag};
+use plist::{Dictionary, Value};
 
 pub fn register() -> JkCommand {
     JkCommand::new()
@@ -31,6 +35,13 @@ pub fn register() -> JkCommand {
             JkFlag::new("wda-timeout")
                 .with_argument(JkArgument::new().required(true))
                 .with_help("WDA readiness timeout in seconds when --bridge is used (default: 30)"),
+        )
+        .with_flag(
+            JkFlag::new("env")
+                .with_argument(JkArgument::new().required(true))
+                .with_help(
+                    "Runner environment as comma-separated KEY=VALUE pairs (escape commas as \\,)",
+                ),
         )
         .with_argument(
             JkArgument::new()
@@ -65,7 +76,7 @@ impl XCUITestListener for PrintListener {
     async fn test_runner_ready_with_capabilities(&mut self) -> Result<(), IdeviceError> {
         println!("[XCTest] Runner ready. Automation session is live.");
         println!(
-            "[XCTest] If this is WDA, device-side endpoints are usually HTTP :8100 and MJPEG :9100."
+            "[XCTest] WDA device-side ports follow USE_PORT and MJPEG_SERVER_PORT from --env."
         );
         Ok(())
     }
@@ -155,6 +166,10 @@ async fn run(
     let use_bridge = arguments.has_flag("bridge");
     let show_wda_debug_logs = arguments.has_flag("wda-debug-log");
     let wda_timeout = arguments.get_flag::<f64>("wda-timeout").unwrap_or(30.0);
+    let runner_env = arguments
+        .get_flag::<String>("env")
+        .map(|value| parse_runner_environment(&value))
+        .transpose()?;
     let runner_bundle_id: String = arguments
         .next_argument()
         .expect("runner bundle ID is required");
@@ -165,12 +180,13 @@ async fn run(
         println!("[XCTest] Target:  {}", t);
     }
 
-    let cfg = build_test_config(
+    let mut cfg = build_test_config(
         provider.as_ref(),
         &runner_bundle_id,
         target_bundle_id.as_deref(),
     )
     .await?;
+    cfg.runner_env = runner_env;
 
     println!("[XCTest] App path:      {}", cfg.runner_app_path);
     println!("[XCTest] Container:     {}", cfg.runner_app_container);
@@ -219,4 +235,129 @@ async fn build_test_config(
     let mut install_proxy = InstallationProxyClient::connect(provider).await?;
     TestConfig::from_installation_proxy(&mut install_proxy, runner_bundle_id, target_bundle_id)
         .await
+}
+
+fn parse_runner_environment(input: &str) -> Result<Dictionary, DvtError> {
+    if input.is_empty() {
+        return Err(DvtError::InvalidXCTestRunnerEnvironment(
+            "environment cannot be empty".into(),
+        ));
+    }
+
+    let mut environment = Dictionary::new();
+    let mut entry = String::new();
+    let mut escaped = false;
+
+    for character in input.chars() {
+        if escaped {
+            match character {
+                ',' | '\\' => entry.push(character),
+                _ => {
+                    entry.push('\\');
+                    entry.push(character);
+                }
+            }
+            escaped = false;
+        } else {
+            match character {
+                '\\' => escaped = true,
+                ',' => {
+                    insert_runner_environment_entry(&mut environment, &entry)?;
+                    entry.clear();
+                }
+                _ => entry.push(character),
+            }
+        }
+    }
+
+    if escaped {
+        return Err(DvtError::InvalidXCTestRunnerEnvironment(
+            "environment cannot end with an escape character".into(),
+        ));
+    }
+
+    insert_runner_environment_entry(&mut environment, &entry)?;
+    Ok(environment)
+}
+
+fn insert_runner_environment_entry(
+    environment: &mut Dictionary,
+    entry: &str,
+) -> Result<(), DvtError> {
+    let (key, value) = entry.split_once('=').ok_or_else(|| {
+        DvtError::InvalidXCTestRunnerEnvironment(format!("expected KEY=VALUE, got {entry:?}"))
+    })?;
+    if key.is_empty() {
+        return Err(DvtError::InvalidXCTestRunnerEnvironment(
+            "environment variable name cannot be empty".into(),
+        ));
+    }
+
+    environment.insert(key.to_owned(), Value::String(value.to_owned()));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_runner_environment;
+
+    #[test]
+    fn parses_runner_environment() {
+        let environment = parse_runner_environment(
+            r"USE_PORT=8200,MJPEG_SERVER_PORT=9200,URL=http://localhost?a=1,EMPTY=",
+        )
+        .unwrap();
+
+        assert_eq!(
+            environment
+                .get("USE_PORT")
+                .and_then(|value| value.as_string()),
+            Some("8200")
+        );
+        assert_eq!(
+            environment
+                .get("MJPEG_SERVER_PORT")
+                .and_then(|value| value.as_string()),
+            Some("9200")
+        );
+        assert_eq!(
+            environment.get("URL").and_then(|value| value.as_string()),
+            Some("http://localhost?a=1")
+        );
+        assert_eq!(
+            environment.get("EMPTY").and_then(|value| value.as_string()),
+            Some("")
+        );
+    }
+
+    #[test]
+    fn parses_escaped_commas_and_backslashes() {
+        let environment = parse_runner_environment(r"LABEL=foo\,bar,PATH=C:\\tmp").unwrap();
+
+        assert_eq!(
+            environment.get("LABEL").and_then(|value| value.as_string()),
+            Some("foo,bar")
+        );
+        assert_eq!(
+            environment.get("PATH").and_then(|value| value.as_string()),
+            Some(r"C:\tmp")
+        );
+    }
+
+    #[test]
+    fn duplicate_environment_variables_use_the_last_value() {
+        let environment = parse_runner_environment("LANG=en,LANG=fr").unwrap();
+
+        assert_eq!(
+            environment.get("LANG").and_then(|value| value.as_string()),
+            Some("fr")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_runner_environment() {
+        for input in ["", "MISSING_VALUE", "=value", "KEY=value,", r"KEY=value\"] {
+            assert!(parse_runner_environment(input).is_err(), "{input:?}");
+        }
+    }
 }


### PR DESCRIPTION
This PR completes support for configuring the XCTest test environment, aligning its behavior with the existing `--env` support in tidevice and pymobiledevice3. 

- Add generic KEY=VALUE parsing for arbitrary XCTest runner environment variables.
- Keep WDA launch, readiness checks, and bridge forwarding on the same explicitly configured ports without overriding defaults when unset.
- Cover parsing and port behavior with unit tests and the existing device test harness.

Now at least in WebDriverAgent, we can use `USE_PORT` and `MJPEG_SERVER_PORT` to override built-in port settings.

Tested on iPhone13 iOS 17.5.1. added unit test and real device tests