### PR TITLE
feat(core_device): add stable mainKeyboard lifecycle and validation

### DIFF
--- a/idevice/src/services/core_device/hid.rs
+++ b/idevice/src/services/core_device/hid.rs
@@ -11,7 +11,7 @@
 //! its RTP payload can be discarded.
 
 use serde::Deserialize;
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeSet, fmt};
 use web_time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
@@ -134,6 +134,239 @@ pub const DIGITIZER_SURFACE_TOUCHSCREEN_GESTURE: u64 = 1281;
 const TOUCHSCREEN_REPORT_SIZE: usize = 58;
 const TOUCHSCREEN_CONTACTS_OFFSET: usize = 3;
 const TOUCHSCREEN_CONTACT_SIZE: usize = 5;
+const MAIN_KEYBOARD_REPORT_ID: u8 = 0x01;
+const MAIN_KEYBOARD_USAGE_BITMAP_BYTES: usize = 29;
+const MAIN_KEYBOARD_REPORT_SIZE: usize = 39;
+const MAIN_KEYBOARD_MIN_USAGE: u16 = 0x01;
+const MAIN_KEYBOARD_MAX_USAGE: u16 = 0xE7;
+const MAIN_KEYBOARD_PRIMARY_USAGE: u64 = 0x06;
+const MAIN_KEYBOARD_PRIMARY_USAGE_PAGE: u64 = 0x01;
+const MAIN_KEYBOARD_VENDOR_ID: i64 = 0x05AC;
+const MAIN_KEYBOARD_PRODUCT_ID: i64 = 0x0250;
+const MAIN_KEYBOARD_REQUESTED_SERVICE_ID: u64 = 0x1_0000_2001;
+const MAIN_KEYBOARD_PRODUCT: &str = "idevice mainKeyboard";
+const MAIN_KEYBOARD_MANUFACTURER: &str = "idevice";
+const MAX_CONNECTED_HID_SERVICES: usize = 256;
+const MAX_HID_PRODUCT_BYTES: usize = 256;
+
+// UniversalHID KeyboardReport descriptor: report ID, 232 usage bits, one
+// constant byte, and eight bytes of remote timestamp/vendor data.
+const MAIN_KEYBOARD_REPORT_DESCRIPTOR: [u8; 56] = [
+    0x85, 0x01, 0x05, 0x07, 0x19, 0x01, 0x29, 0xE7, 0x96, 0xE8, 0x00, 0x75, 0x01, 0x15, 0x01, 0x26,
+    0xE7, 0x00, 0x81, 0x02, 0xA1, 0x02, 0x06, 0x1A, 0xFF, 0x0A, 0xF1, 0xE0, 0x19, 0x00, 0x29, 0x00,
+    0x75, 0x08, 0x95, 0x01, 0x81, 0x01, 0xC0, 0x06, 0x00, 0xFF, 0x0A, 0x02, 0x01, 0x15, 0x00, 0x26,
+    0xFF, 0x00, 0x75, 0x08, 0x95, 0x08, 0x81, 0x02,
+];
+
+/// A validated HID Keyboard/Keypad-page usage accepted by mainKeyboard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct KeyboardUsage(u8);
+
+impl KeyboardUsage {
+    pub fn new(raw: u16) -> Result<Self, MainKeyboardError> {
+        if !(MAIN_KEYBOARD_MIN_USAGE..=MAIN_KEYBOARD_MAX_USAGE).contains(&raw) {
+            return Err(MainKeyboardError::InvalidUsage);
+        }
+        Ok(Self(raw as u8))
+    }
+
+    pub const fn raw(self) -> u8 {
+        self.0
+    }
+
+    const fn bitmap_position(self) -> (usize, u8) {
+        let usage = self.0 as usize;
+        (usage / 8, 1 << (usage % 8))
+    }
+}
+
+/// Content-free failure categories for the fixed mainKeyboard lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MainKeyboardError {
+    #[error("mainKeyboard transport is unavailable")]
+    Transport,
+    #[error("mainKeyboard response is malformed")]
+    MalformedResponse,
+    #[error("mainKeyboard service was not visible after creation")]
+    ServiceNotVisible,
+    #[error("mainKeyboard service identity was ambiguous")]
+    AmbiguousIdentity,
+    #[error("mainKeyboard metadata evidence was missing")]
+    MetadataMissing,
+    #[error("mainKeyboard metadata evidence was invalid")]
+    MetadataInvalid,
+    #[error("mainKeyboard usage identity did not match")]
+    UsageMismatch,
+    #[error("mainKeyboard codable identity evidence was missing")]
+    IdentityEvidenceMissing,
+    #[error("mainKeyboard virtual-service identity did not match")]
+    VirtualServiceMismatch,
+    #[error("mainKeyboard report descriptor identity did not match")]
+    DescriptorMismatch,
+    #[error("mainKeyboard constructor rollback failed")]
+    RollbackFailed,
+    #[error("mainKeyboard service is no longer active")]
+    Inactive,
+    #[error("mainKeyboard usage is outside the supported report range")]
+    InvalidUsage,
+    #[error("mainKeyboard key is already pressed")]
+    KeyAlreadyPressed,
+    #[error("mainKeyboard key is not pressed")]
+    KeyNotPressed,
+    #[error("mainKeyboard service remained registered after removal")]
+    StillRegistered,
+}
+
+struct MainKeyboardOwnership;
+
+/// Opaque owner token for one confirmed fixed mainKeyboard service.
+///
+/// The device service identifier and pressed-key report stay inside this
+/// adapter. The token is intentionally neither `Clone` nor externally
+/// constructible, preventing callers from aliasing cleanup ownership.
+pub struct MainKeyboardService {
+    service_id: u64,
+    pressed: [u8; MAIN_KEYBOARD_USAGE_BITMAP_BYTES],
+    active: bool,
+    _ownership: MainKeyboardOwnership,
+}
+
+impl MainKeyboardService {
+    pub const fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn pressed_count(&self) -> usize {
+        self.pressed
+            .iter()
+            .map(|byte| byte.count_ones() as usize)
+            .sum()
+    }
+}
+
+impl fmt::Debug for MainKeyboardService {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MainKeyboardService")
+            .field("service_id", &"<redacted>")
+            .field("pressed_count", &self.pressed_count())
+            .field("active", &self.active)
+            .finish()
+    }
+}
+
+fn universal_hid_request(payload: Dictionary) -> Dictionary {
+    let mut request = Dictionary::new();
+    let universal_hid_feature: Cow<'static, str> =
+        obf!("com.apple.coredevice.feature.remote.universalhidservice");
+    request.insert(
+        "featureIdentifier".into(),
+        XPCObject::String(universal_hid_feature.into()),
+    );
+    request.insert("messageType".into(), XPCObject::String("Request".into()));
+    request.insert("payload".into(), XPCObject::Dictionary(payload));
+    request
+}
+
+fn build_connected_services_request() -> Dictionary {
+    let mut payload = Dictionary::new();
+    payload.insert(
+        "connectedServices".into(),
+        XPCObject::Dictionary(Dictionary::new()),
+    );
+    universal_hid_request(payload)
+}
+
+fn build_main_keyboard_create_request() -> Dictionary {
+    let payload = crate::xpc!({
+        "createService": {
+            "_0": {
+                "DeviceUsagePairs": [{
+                    "DeviceUsage": MAIN_KEYBOARD_PRIMARY_USAGE as i64,
+                    "DeviceUsagePage": MAIN_KEYBOARD_PRIMARY_USAGE_PAGE as i64,
+                }],
+                "PrimaryUsage": MAIN_KEYBOARD_PRIMARY_USAGE,
+                "PrimaryUsagePage": MAIN_KEYBOARD_PRIMARY_USAGE_PAGE,
+                "Product": MAIN_KEYBOARD_PRODUCT,
+                "ProductID": MAIN_KEYBOARD_PRODUCT_ID,
+                "VendorID": MAIN_KEYBOARD_VENDOR_ID,
+                "_CoreDevice_codablePropertyStorage": {
+                    "Manufacturer": { "string": MAIN_KEYBOARD_MANUFACTURER },
+                    "Product": { "string": MAIN_KEYBOARD_PRODUCT },
+                    "ProductID": { "int": MAIN_KEYBOARD_PRODUCT_ID },
+                    "VendorID": { "int": MAIN_KEYBOARD_VENDOR_ID },
+                    "PrimaryUsage": { "int": MAIN_KEYBOARD_PRIMARY_USAGE as i64 },
+                    "PrimaryUsagePage": {
+                        "int": MAIN_KEYBOARD_PRIMARY_USAGE_PAGE as i64,
+                    },
+                    "DeviceUsagePairs": {
+                        "array": [{
+                            "dictionary": {
+                                "DeviceUsage": {
+                                    "int": MAIN_KEYBOARD_PRIMARY_USAGE as i64,
+                                },
+                                "DeviceUsagePage": {
+                                    "int": MAIN_KEYBOARD_PRIMARY_USAGE_PAGE as i64,
+                                },
+                            },
+                        }],
+                    },
+                    "Transport": { "string": "USB" },
+                    "ReportDescriptor": {
+                        "data": MAIN_KEYBOARD_REPORT_DESCRIPTOR.to_vec(),
+                    },
+                    "UniversalControlVirtualService": { "bool": true },
+                    "_ServiceID": { "uint": MAIN_KEYBOARD_REQUESTED_SERVICE_ID },
+                },
+                "_ServiceID": MAIN_KEYBOARD_REQUESTED_SERVICE_ID,
+            },
+        },
+    })
+    .to_dictionary()
+    .expect("mainKeyboard payload is a dictionary");
+    universal_hid_request(payload)
+}
+
+fn build_main_keyboard_service_request(operation: &'static str, service_id: u64) -> Dictionary {
+    let mut tuple = Dictionary::new();
+    tuple.insert("_0".into(), XPCObject::UInt64(service_id));
+    let mut payload = Dictionary::new();
+    payload.insert(operation.into(), XPCObject::Dictionary(tuple));
+    universal_hid_request(payload)
+}
+
+fn main_keyboard_usage_bitmap(
+    usages: impl IntoIterator<Item = KeyboardUsage>,
+) -> [u8; MAIN_KEYBOARD_USAGE_BITMAP_BYTES] {
+    let mut bitmap = [0; MAIN_KEYBOARD_USAGE_BITMAP_BYTES];
+    for usage in usages {
+        let (byte, mask) = usage.bitmap_position();
+        bitmap[byte] |= mask;
+    }
+    bitmap
+}
+
+fn build_main_keyboard_report(bitmap: &[u8; MAIN_KEYBOARD_USAGE_BITMAP_BYTES]) -> Vec<u8> {
+    let timestamp = default_timestamp();
+    let mut report = Vec::with_capacity(MAIN_KEYBOARD_REPORT_SIZE);
+    report.push(MAIN_KEYBOARD_REPORT_ID);
+    report.extend_from_slice(bitmap);
+    report.push(0);
+    report.extend_from_slice(&timestamp.to_le_bytes()[..6]);
+    report.extend_from_slice(&[0, 0]);
+    debug_assert_eq!(report.len(), MAIN_KEYBOARD_REPORT_SIZE);
+    report
+}
+
+fn build_send_report_request(service_id: u64, report: Vec<u8>) -> Dictionary {
+    let mut tuple = Dictionary::new();
+    tuple.insert("_0".into(), XPCObject::Data(report));
+    tuple.insert("_1".into(), XPCObject::UInt64(service_id));
+    let mut payload = Dictionary::new();
+    payload.insert("send".into(), XPCObject::Dictionary(tuple));
+    universal_hid_request(payload)
+}
 
 /// One contact in a `mainTouchscreen` HID report.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -482,6 +715,148 @@ pub struct HidSurface {
     pub primary_usage_page: Option<u64>,
 }
 
+fn parse_hid_surfaces(response: &plist::Value) -> Result<Vec<HidSurface>, IdeviceError> {
+    let services = response
+        .as_dictionary()
+        .and_then(|dictionary| dictionary.get("connectedServices"))
+        .ok_or(CoreDeviceError::MissingField("connectedServices"))?;
+    let surfaces: Vec<HidSurface> = plist::from_value(services)
+        .map_err(|_| CoreDeviceError::MalformedField("connectedServices"))?;
+    if surfaces.len() > MAX_CONNECTED_HID_SERVICES {
+        return Err(CoreDeviceError::MalformedField("connectedServices").into());
+    }
+
+    let mut identifiers = BTreeSet::new();
+    for surface in &surfaces {
+        if surface.service_id == 0 || !identifiers.insert(surface.service_id) {
+            return Err(CoreDeviceError::MalformedField("connectedServices").into());
+        }
+        if surface.product.as_ref().is_some_and(|product| {
+            product.is_empty()
+                || product.len() > MAX_HID_PRODUCT_BYTES
+                || product.chars().any(char::is_control)
+        }) || surface
+            .primary_usage
+            .is_some_and(|usage| usage > u64::from(u16::MAX))
+            || surface
+                .primary_usage_page
+                .is_some_and(|usage_page| usage_page > u64::from(u16::MAX))
+        {
+            return Err(CoreDeviceError::MalformedField("connectedServices").into());
+        }
+    }
+    Ok(surfaces)
+}
+
+fn parse_created_main_keyboard_id(response: &plist::Value) -> Result<u64, MainKeyboardError> {
+    response
+        .as_dictionary()
+        .and_then(|dictionary| dictionary.get("serviceID"))
+        .and_then(plist::Value::as_unsigned_integer)
+        .filter(|service_id| *service_id != 0)
+        .ok_or(MainKeyboardError::MalformedResponse)
+}
+
+fn codable_storage_value<'a>(
+    storage: &'a plist::Dictionary,
+    key: &str,
+    tag: &str,
+) -> Option<&'a plist::Value> {
+    storage
+        .get(key)
+        .and_then(plist::Value::as_dictionary)
+        .and_then(|wrapper| wrapper.get(tag))
+}
+
+fn confirm_main_keyboard_identity(
+    response: &plist::Value,
+    service_id: u64,
+) -> Result<(), MainKeyboardError> {
+    let encoded = response
+        .as_dictionary()
+        .and_then(|dictionary| dictionary.get("connectedServices"))
+        .and_then(plist::Value::as_array)
+        .ok_or(MainKeyboardError::MalformedResponse)?;
+    if encoded.len() > MAX_CONNECTED_HID_SERVICES {
+        return Err(MainKeyboardError::MalformedResponse);
+    }
+
+    let mut matching = encoded.iter().filter_map(|value| {
+        let dictionary = value.as_dictionary()?;
+        (dictionary
+            .get("_ServiceID")
+            .and_then(plist::Value::as_unsigned_integer)
+            == Some(service_id))
+        .then_some(dictionary)
+    });
+    let Some(surface) = matching.next() else {
+        return Err(MainKeyboardError::ServiceNotVisible);
+    };
+    if matching.next().is_some() {
+        return Err(MainKeyboardError::AmbiguousIdentity);
+    }
+    if surface
+        .get("PrimaryUsagePage")
+        .and_then(plist::Value::as_unsigned_integer)
+        != Some(MAIN_KEYBOARD_PRIMARY_USAGE_PAGE)
+        || surface
+            .get("PrimaryUsage")
+            .and_then(plist::Value::as_unsigned_integer)
+            != Some(MAIN_KEYBOARD_PRIMARY_USAGE)
+    {
+        return Err(MainKeyboardError::UsageMismatch);
+    }
+
+    let storage = surface
+        .get("_CoreDevice_codablePropertyStorage")
+        .and_then(plist::Value::as_dictionary)
+        .ok_or(MainKeyboardError::IdentityEvidenceMissing)?;
+    if codable_storage_value(storage, "_ServiceID", "uint")
+        .and_then(plist::Value::as_unsigned_integer)
+        != Some(service_id)
+    {
+        return Err(MainKeyboardError::IdentityEvidenceMissing);
+    }
+    if codable_storage_value(storage, "PrimaryUsagePage", "int")
+        .and_then(plist::Value::as_unsigned_integer)
+        != Some(MAIN_KEYBOARD_PRIMARY_USAGE_PAGE)
+        || codable_storage_value(storage, "PrimaryUsage", "int")
+            .and_then(plist::Value::as_unsigned_integer)
+            != Some(MAIN_KEYBOARD_PRIMARY_USAGE)
+    {
+        return Err(MainKeyboardError::UsageMismatch);
+    }
+    if codable_storage_value(storage, "UniversalControlVirtualService", "bool")
+        .and_then(plist::Value::as_boolean)
+        != Some(true)
+    {
+        return Err(MainKeyboardError::VirtualServiceMismatch);
+    }
+    if codable_storage_value(storage, "ReportDescriptor", "data").and_then(plist::Value::as_data)
+        != Some(MAIN_KEYBOARD_REPORT_DESCRIPTOR.as_slice())
+    {
+        return Err(MainKeyboardError::DescriptorMismatch);
+    }
+    for key in ["Product", "Manufacturer"] {
+        let value = codable_storage_value(storage, key, "string")
+            .and_then(plist::Value::as_string)
+            .ok_or(MainKeyboardError::MetadataMissing)?;
+        if value.is_empty()
+            || value.len() > MAX_HID_PRODUCT_BYTES
+            || value.chars().any(char::is_control)
+        {
+            return Err(MainKeyboardError::MetadataInvalid);
+        }
+    }
+    Ok(())
+}
+
+trait MainKeyboardWire {
+    async fn request(&mut self, request: Dictionary) -> Result<plist::Value, MainKeyboardError>;
+
+    async fn send(&mut self, request: Dictionary) -> Result<(), MainKeyboardError>;
+}
+
 /// Inspect and drive the device's registered HID surfaces.
 #[derive(Debug)]
 pub struct UniversalHidServiceClient<R: ReadWrite> {
@@ -501,43 +876,220 @@ impl crate::RsdService for UniversalHidServiceClient<Box<dyn ReadWrite>> {
     }
 }
 
+impl<R: ReadWrite> MainKeyboardWire for UniversalHidServiceClient<R> {
+    async fn request(&mut self, request: Dictionary) -> Result<plist::Value, MainKeyboardError> {
+        self.inner
+            .send_object(request, true)
+            .await
+            .map_err(|_| MainKeyboardError::Transport)?;
+        self.inner
+            .recv()
+            .await
+            .map_err(|_| MainKeyboardError::Transport)
+    }
+
+    async fn send(&mut self, request: Dictionary) -> Result<(), MainKeyboardError> {
+        self.inner
+            .send_object(request, false)
+            .await
+            .map_err(|_| MainKeyboardError::Transport)
+    }
+}
+
+async fn connected_services_response(
+    wire: &mut impl MainKeyboardWire,
+) -> Result<plist::Value, MainKeyboardError> {
+    wire.request(build_connected_services_request()).await
+}
+
+async fn list_hid_surfaces_on_wire(
+    wire: &mut impl MainKeyboardWire,
+) -> Result<Vec<HidSurface>, MainKeyboardError> {
+    let response = connected_services_response(wire).await?;
+    parse_hid_surfaces(&response).map_err(|_| MainKeyboardError::MalformedResponse)
+}
+
+async fn confirm_main_keyboard_on_wire(
+    wire: &mut impl MainKeyboardWire,
+    service_id: u64,
+) -> Result<(), MainKeyboardError> {
+    let response = connected_services_response(wire).await?;
+    parse_hid_surfaces(&response).map_err(|_| MainKeyboardError::MalformedResponse)?;
+    confirm_main_keyboard_identity(&response, service_id)
+}
+
+async fn create_main_keyboard_on_wire(
+    wire: &mut impl MainKeyboardWire,
+) -> Result<MainKeyboardService, MainKeyboardError> {
+    let response = wire.request(build_main_keyboard_create_request()).await?;
+    let service_id = parse_created_main_keyboard_id(&response)?;
+
+    let confirmation = confirm_main_keyboard_on_wire(wire, service_id).await;
+    if let Err(error) = confirmation {
+        let rollback = wire
+            .send(build_main_keyboard_service_request(
+                "removeService",
+                service_id,
+            ))
+            .await;
+        if rollback.is_err() {
+            return Err(MainKeyboardError::RollbackFailed);
+        }
+        return Err(error);
+    }
+
+    Ok(MainKeyboardService {
+        service_id,
+        pressed: [0; MAIN_KEYBOARD_USAGE_BITMAP_BYTES],
+        active: true,
+        _ownership: MainKeyboardOwnership,
+    })
+}
+
+async fn replace_main_keyboard_usages_on_wire(
+    wire: &mut impl MainKeyboardWire,
+    service: &mut MainKeyboardService,
+    pressed: [u8; MAIN_KEYBOARD_USAGE_BITMAP_BYTES],
+) -> Result<(), MainKeyboardError> {
+    if !service.active {
+        return Err(MainKeyboardError::Inactive);
+    }
+    wire.send(build_send_report_request(
+        service.service_id,
+        build_main_keyboard_report(&pressed),
+    ))
+    .await?;
+    service.pressed = pressed;
+    Ok(())
+}
+
+async fn reset_main_keyboard_on_wire(
+    wire: &mut impl MainKeyboardWire,
+    service: &mut MainKeyboardService,
+) -> Result<(), MainKeyboardError> {
+    if !service.active {
+        return Ok(());
+    }
+    wire.send(build_main_keyboard_service_request(
+        "resetGestureState",
+        service.service_id,
+    ))
+    .await?;
+    service.pressed.fill(0);
+    Ok(())
+}
+
+async fn remove_main_keyboard_on_wire(
+    wire: &mut impl MainKeyboardWire,
+    service: &mut MainKeyboardService,
+) -> Result<(), MainKeyboardError> {
+    if !service.active {
+        return Ok(());
+    }
+
+    // Removal is the stronger cleanup operation, so attempt it even when the
+    // preceding state reset cannot be delivered.
+    let _reset_result = wire
+        .send(build_main_keyboard_service_request(
+            "resetGestureState",
+            service.service_id,
+        ))
+        .await;
+    wire.send(build_main_keyboard_service_request(
+        "removeService",
+        service.service_id,
+    ))
+    .await?;
+    let surfaces = list_hid_surfaces_on_wire(wire).await?;
+    if surfaces
+        .iter()
+        .any(|surface| surface.service_id == service.service_id)
+    {
+        return Err(MainKeyboardError::StillRegistered);
+    }
+
+    service.pressed.fill(0);
+    service.active = false;
+    Ok(())
+}
+
 impl<R: ReadWrite> UniversalHidServiceClient<R> {
     pub fn new(inner: RemoteXpcClient<R>) -> Self {
         Self { inner }
     }
 
-    /// Build the `{featureIdentifier, messageType: "Request", payload}` envelope
-    /// these requests share.
-    fn request(payload: Dictionary) -> Dictionary {
-        let mut msg = Dictionary::new();
-        let universal_hid_feature: Cow<'static, str> =
-            obf!("com.apple.coredevice.feature.remote.universalhidservice");
-        msg.insert(
-            "featureIdentifier".into(),
-            XPCObject::String(universal_hid_feature.into()),
-        );
-        msg.insert("messageType".into(), XPCObject::String("Request".into()));
-        msg.insert("payload".into(), XPCObject::Dictionary(payload));
-        msg
-    }
-
     /// Enumerate the device's currently-registered HID surfaces.
     pub async fn list_connected_services(&mut self) -> Result<Vec<HidSurface>, IdeviceError> {
-        let mut payload = Dictionary::new();
-        payload.insert(
-            "connectedServices".into(),
-            XPCObject::Dictionary(Dictionary::new()),
-        );
-        let msg = Self::request(payload);
+        let msg = build_connected_services_request();
         self.inner.send_object(msg, true).await?;
         let res = self.inner.recv().await?;
+        parse_hid_surfaces(&res)
+    }
 
-        let services = res
-            .as_dictionary()
-            .and_then(|d| d.get("connectedServices"))
-            .ok_or(CoreDeviceError::MissingField("connectedServices"))?;
-        plist::from_value(services)
-            .map_err(|_| CoreDeviceError::MalformedField("connectedServices").into())
+    /// Create and confirm the fixed mainKeyboard service.
+    ///
+    /// If the device-assigned identity cannot be confirmed, the constructor
+    /// sends a bounded rollback removal before returning an error.
+    pub async fn create_main_keyboard(&mut self) -> Result<MainKeyboardService, MainKeyboardError> {
+        create_main_keyboard_on_wire(self).await
+    }
+
+    /// Atomically replace the complete pressed-key set for mainKeyboard.
+    pub async fn set_main_keyboard_usages(
+        &mut self,
+        service: &mut MainKeyboardService,
+        pressed: impl IntoIterator<Item = KeyboardUsage>,
+    ) -> Result<(), MainKeyboardError> {
+        replace_main_keyboard_usages_on_wire(self, service, main_keyboard_usage_bitmap(pressed))
+            .await
+    }
+
+    /// Add one key to the pressed-key set and send the complete bounded report.
+    pub async fn main_keyboard_key_down(
+        &mut self,
+        service: &mut MainKeyboardService,
+        usage: KeyboardUsage,
+    ) -> Result<(), MainKeyboardError> {
+        let mut pressed = service.pressed;
+        let (byte, mask) = usage.bitmap_position();
+        if pressed[byte] & mask != 0 {
+            return Err(MainKeyboardError::KeyAlreadyPressed);
+        }
+        pressed[byte] |= mask;
+        replace_main_keyboard_usages_on_wire(self, service, pressed).await
+    }
+
+    /// Remove one key from the pressed-key set and send the complete report.
+    pub async fn main_keyboard_key_up(
+        &mut self,
+        service: &mut MainKeyboardService,
+        usage: KeyboardUsage,
+    ) -> Result<(), MainKeyboardError> {
+        let mut pressed = service.pressed;
+        let (byte, mask) = usage.bitmap_position();
+        if pressed[byte] & mask == 0 {
+            return Err(MainKeyboardError::KeyNotPressed);
+        }
+        pressed[byte] &= !mask;
+        replace_main_keyboard_usages_on_wire(self, service, pressed).await
+    }
+
+    /// Reset mainKeyboard gesture/key state. Repeated reset after removal is a
+    /// no-op so teardown callers may safely converge.
+    pub async fn reset_main_keyboard(
+        &mut self,
+        service: &mut MainKeyboardService,
+    ) -> Result<(), MainKeyboardError> {
+        reset_main_keyboard_on_wire(self, service).await
+    }
+
+    /// Reset, remove, and confirm absence of mainKeyboard. This operation is
+    /// idempotent after successful removal.
+    pub async fn remove_main_keyboard(
+        &mut self,
+        service: &mut MainKeyboardService,
+    ) -> Result<(), MainKeyboardError> {
+        remove_main_keyboard_on_wire(self, service).await
     }
 
     /// Deliver a raw HID report to one of the device's HID surfaces.
@@ -547,16 +1099,7 @@ impl<R: ReadWrite> UniversalHidServiceClient<R> {
         report: Vec<u8>,
     ) -> Result<(), IdeviceError> {
         // `send` is a Swift tuple `(_0: report, _1: serviceID)`.
-        let payload = crate::xpc!({
-            "send": {
-                "_0": report,
-                "_1": service_id
-            }
-        })
-        .to_dictionary()
-        .unwrap();
-
-        let msg = Self::request(payload);
+        let msg = build_send_report_request(service_id, report);
         self.inner.send_object(msg, false).await
     }
 
@@ -664,6 +1207,125 @@ impl<R: ReadWrite> UniversalHidServiceClient<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+
+    #[derive(Default)]
+    struct FakeMainKeyboardWire {
+        replies: VecDeque<Result<plist::Value, MainKeyboardError>>,
+        send_results: VecDeque<Result<(), MainKeyboardError>>,
+        sent: Vec<(Dictionary, bool)>,
+    }
+
+    impl MainKeyboardWire for FakeMainKeyboardWire {
+        async fn request(
+            &mut self,
+            request: Dictionary,
+        ) -> Result<plist::Value, MainKeyboardError> {
+            self.sent.push((request, true));
+            self.replies
+                .pop_front()
+                .unwrap_or(Err(MainKeyboardError::MalformedResponse))
+        }
+
+        async fn send(&mut self, request: Dictionary) -> Result<(), MainKeyboardError> {
+            self.sent.push((request, false));
+            self.send_results.pop_front().unwrap_or(Ok(()))
+        }
+    }
+
+    fn created_service(service_id: u64) -> plist::Value {
+        crate::plist!({ "serviceID": service_id })
+    }
+
+    fn connected_services(surfaces: Vec<plist::Value>) -> plist::Value {
+        crate::plist!({ "connectedServices": surfaces })
+    }
+
+    fn hid_surface(
+        service_id: u64,
+        product: &str,
+        primary_usage_page: u64,
+        primary_usage: u64,
+    ) -> plist::Value {
+        crate::plist!({
+            "_ServiceID": service_id,
+            "Product": product,
+            "PrimaryUsagePage": primary_usage_page,
+            "PrimaryUsage": primary_usage,
+            "_CoreDevice_codablePropertyStorage": {
+                "_ServiceID": { "uint": service_id },
+                "Product": { "string": product },
+                "Manufacturer": { "string": MAIN_KEYBOARD_MANUFACTURER },
+                "PrimaryUsagePage": { "int": primary_usage_page },
+                "PrimaryUsage": { "int": primary_usage },
+                "UniversalControlVirtualService": { "bool": true },
+                "ReportDescriptor": { "data": MAIN_KEYBOARD_REPORT_DESCRIPTOR.to_vec() },
+            },
+        })
+    }
+
+    fn codable_storage_mut(surface: &mut plist::Value) -> &mut plist::Dictionary {
+        surface
+            .as_dictionary_mut()
+            .and_then(|surface| surface.get_mut("_CoreDevice_codablePropertyStorage"))
+            .and_then(plist::Value::as_dictionary_mut)
+            .expect("codable storage")
+    }
+
+    fn operation_payload<'a>(request: &'a Dictionary, operation: &str) -> &'a Dictionary {
+        request
+            .get("payload")
+            .and_then(XPCObject::as_dictionary)
+            .and_then(|payload| payload.get(operation))
+            .and_then(XPCObject::as_dictionary)
+            .expect("operation payload")
+    }
+
+    fn hid_input_bits_for_report(descriptor: &[u8], target_report_id: u8) -> usize {
+        let mut offset = 0;
+        let mut report_id = 0;
+        let mut report_size = 0;
+        let mut report_count = 0;
+        let mut input_bits = 0;
+
+        while offset < descriptor.len() {
+            let prefix = descriptor[offset];
+            offset += 1;
+            assert_ne!(
+                prefix, 0xFE,
+                "long HID items are not supported by this test"
+            );
+            let data_len = match prefix & 0x03 {
+                0 => 0,
+                1 => 1,
+                2 => 2,
+                3 => 4,
+                _ => unreachable!(),
+            };
+            assert!(offset + data_len <= descriptor.len());
+            let value = descriptor[offset..offset + data_len]
+                .iter()
+                .enumerate()
+                .fold(0usize, |value, (index, byte)| {
+                    value | (usize::from(*byte) << (index * 8))
+                });
+            offset += data_len;
+
+            let item_type = (prefix >> 2) & 0x03;
+            let item_tag = prefix >> 4;
+            match (item_type, item_tag) {
+                (1, 7) => report_size = value,
+                (1, 8) => report_id = value as u8,
+                (1, 9) => report_count = value,
+                (0, 8) if report_id == target_report_id => {
+                    input_bits += report_size * report_count;
+                }
+                _ => {}
+            }
+        }
+
+        input_bits
+    }
 
     #[test]
     fn digitizer_report_layout() {
@@ -790,5 +1452,337 @@ mod tests {
         assert_eq!(contacts[0].identity, 0);
         assert_eq!(contacts[1].identity, 1);
         assert!(contacts.iter().all(|contact| contact.touching));
+    }
+
+    #[test]
+    fn main_keyboard_create_request_is_fixed_and_bounded() {
+        let request = build_main_keyboard_create_request();
+        assert_eq!(
+            request.get("featureIdentifier"),
+            Some(&XPCObject::String(
+                "com.apple.coredevice.feature.remote.universalhidservice".into()
+            ))
+        );
+        assert_eq!(
+            request.get("messageType"),
+            Some(&XPCObject::String("Request".into()))
+        );
+
+        let properties = operation_payload(&request, "createService")
+            .get("_0")
+            .and_then(XPCObject::as_dictionary)
+            .expect("fixed descriptor");
+        assert_eq!(
+            properties.get("Product"),
+            Some(&XPCObject::String(MAIN_KEYBOARD_PRODUCT.into()))
+        );
+        assert_eq!(
+            properties.get("PrimaryUsagePage"),
+            Some(&XPCObject::UInt64(1))
+        );
+        assert_eq!(properties.get("PrimaryUsage"), Some(&XPCObject::UInt64(6)));
+
+        let storage = properties
+            .get("_CoreDevice_codablePropertyStorage")
+            .and_then(XPCObject::as_dictionary)
+            .expect("codable storage");
+        assert_eq!(
+            storage
+                .get("ReportDescriptor")
+                .and_then(XPCObject::as_dictionary)
+                .and_then(|value| value.get("data")),
+            Some(&XPCObject::Data(MAIN_KEYBOARD_REPORT_DESCRIPTOR.to_vec()))
+        );
+        assert_eq!(
+            storage
+                .get("UniversalControlVirtualService")
+                .and_then(XPCObject::as_dictionary)
+                .and_then(|value| value.get("bool")),
+            Some(&XPCObject::Bool(true))
+        );
+    }
+
+    #[test]
+    fn main_keyboard_descriptor_matches_the_report_layout() {
+        assert_eq!(MAIN_KEYBOARD_REPORT_DESCRIPTOR.len(), 56);
+        assert_eq!(
+            &MAIN_KEYBOARD_REPORT_DESCRIPTOR[..2],
+            &[0x85, MAIN_KEYBOARD_REPORT_ID]
+        );
+
+        let input_bits =
+            hid_input_bits_for_report(&MAIN_KEYBOARD_REPORT_DESCRIPTOR, MAIN_KEYBOARD_REPORT_ID);
+        assert_eq!(input_bits, 304);
+        assert_eq!(input_bits % 8, 0);
+        assert_eq!(input_bits / 8 + 1, MAIN_KEYBOARD_REPORT_SIZE);
+
+        let report = build_main_keyboard_report(&[0; MAIN_KEYBOARD_USAGE_BITMAP_BYTES]);
+        assert_eq!(report.len(), MAIN_KEYBOARD_REPORT_SIZE);
+        assert_eq!(report[0], MAIN_KEYBOARD_REPORT_ID);
+        assert_eq!(report[30], 0);
+        assert_eq!(&report[37..], &[0, 0]);
+    }
+
+    #[tokio::test]
+    async fn main_keyboard_constructor_confirms_the_assigned_identity() {
+        let assigned = 0x1_0000_3001;
+        let mut wire = FakeMainKeyboardWire {
+            replies: VecDeque::from([
+                Ok(created_service(assigned)),
+                Ok(connected_services(vec![hid_surface(
+                    assigned,
+                    MAIN_KEYBOARD_PRODUCT,
+                    MAIN_KEYBOARD_PRIMARY_USAGE_PAGE,
+                    MAIN_KEYBOARD_PRIMARY_USAGE,
+                )])),
+            ]),
+            ..FakeMainKeyboardWire::default()
+        };
+
+        let service = create_main_keyboard_on_wire(&mut wire).await.unwrap();
+
+        assert!(service.is_active());
+        assert_eq!(service.pressed_count(), 0);
+        assert_eq!(wire.sent.len(), 2);
+        assert!(wire.sent.iter().all(|(_, expects_reply)| *expects_reply));
+        let debug = format!("{service:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(&assigned.to_string()));
+    }
+
+    #[tokio::test]
+    async fn main_keyboard_constructor_rolls_back_an_identity_mismatch() {
+        let assigned = 0x1_0000_3001;
+        let mut mismatched = hid_surface(
+            assigned,
+            MAIN_KEYBOARD_PRODUCT,
+            MAIN_KEYBOARD_PRIMARY_USAGE_PAGE,
+            MAIN_KEYBOARD_PRIMARY_USAGE,
+        );
+        codable_storage_mut(&mut mismatched)
+            .get_mut("ReportDescriptor")
+            .and_then(plist::Value::as_dictionary_mut)
+            .unwrap()
+            .insert("data".into(), plist::Value::Data(vec![0]));
+        let mut wire = FakeMainKeyboardWire {
+            replies: VecDeque::from([
+                Ok(created_service(assigned)),
+                Ok(connected_services(vec![mismatched])),
+            ]),
+            ..FakeMainKeyboardWire::default()
+        };
+
+        assert_eq!(
+            create_main_keyboard_on_wire(&mut wire).await.unwrap_err(),
+            MainKeyboardError::DescriptorMismatch
+        );
+        assert_eq!(wire.sent.len(), 3);
+        assert!(!wire.sent[2].1);
+        assert_eq!(
+            operation_payload(&wire.sent[2].0, "removeService").get("_0"),
+            Some(&XPCObject::UInt64(assigned))
+        );
+    }
+
+    #[test]
+    fn main_keyboard_identity_diagnostics_remain_unique_and_content_free() {
+        let assigned = 0x1_0000_3001;
+        let expected = hid_surface(
+            assigned,
+            MAIN_KEYBOARD_PRODUCT,
+            MAIN_KEYBOARD_PRIMARY_USAGE_PAGE,
+            MAIN_KEYBOARD_PRIMARY_USAGE,
+        );
+        let mut missing_metadata = expected.clone();
+        codable_storage_mut(&mut missing_metadata).remove("Product");
+        let mut invalid_metadata = expected.clone();
+        codable_storage_mut(&mut invalid_metadata)
+            .get_mut("Manufacturer")
+            .and_then(plist::Value::as_dictionary_mut)
+            .unwrap()
+            .insert(
+                "string".into(),
+                plist::Value::String("invalid\nmetadata".into()),
+            );
+        let failures = [
+            confirm_main_keyboard_identity(&connected_services(Vec::new()), assigned).unwrap_err(),
+            confirm_main_keyboard_identity(
+                &connected_services(vec![expected.clone(), expected]),
+                assigned,
+            )
+            .unwrap_err(),
+            confirm_main_keyboard_identity(
+                &connected_services(vec![hid_surface(assigned, MAIN_KEYBOARD_PRODUCT, 1, 7)]),
+                assigned,
+            )
+            .unwrap_err(),
+            confirm_main_keyboard_identity(&connected_services(vec![missing_metadata]), assigned)
+                .unwrap_err(),
+            confirm_main_keyboard_identity(&connected_services(vec![invalid_metadata]), assigned)
+                .unwrap_err(),
+        ];
+
+        assert_eq!(failures[0], MainKeyboardError::ServiceNotVisible);
+        assert_eq!(failures[1], MainKeyboardError::AmbiguousIdentity);
+        assert_eq!(failures[2], MainKeyboardError::UsageMismatch);
+        assert_eq!(failures[3], MainKeyboardError::MetadataMissing);
+        assert_eq!(failures[4], MainKeyboardError::MetadataInvalid);
+        for error in failures {
+            let rendered = error.to_string();
+            assert!(!rendered.contains(&assigned.to_string()));
+            assert!(!rendered.contains("invalid\nmetadata"));
+        }
+    }
+
+    #[test]
+    fn main_keyboard_confirmation_accepts_a_device_normalized_top_level_product() {
+        let assigned = 0x1_0000_3001;
+        let mut surface = hid_surface(
+            assigned,
+            MAIN_KEYBOARD_PRODUCT,
+            MAIN_KEYBOARD_PRIMARY_USAGE_PAGE,
+            MAIN_KEYBOARD_PRIMARY_USAGE,
+        );
+        surface
+            .as_dictionary_mut()
+            .unwrap()
+            .insert("Product".into(), "device-normalized keyboard".into());
+        let storage = codable_storage_mut(&mut surface);
+        storage
+            .get_mut("Product")
+            .and_then(plist::Value::as_dictionary_mut)
+            .unwrap()
+            .insert("string".into(), "normalized keyboard".into());
+        storage
+            .get_mut("Manufacturer")
+            .and_then(plist::Value::as_dictionary_mut)
+            .unwrap()
+            .insert("string".into(), "normalized manufacturer".into());
+        let response = connected_services(vec![surface]);
+
+        assert_eq!(confirm_main_keyboard_identity(&response, assigned), Ok(()));
+    }
+
+    #[tokio::test]
+    async fn main_keyboard_constructor_reports_a_failed_rollback() {
+        let assigned = 0x1_0000_3001;
+        let mut wire = FakeMainKeyboardWire {
+            replies: VecDeque::from([
+                Ok(created_service(assigned)),
+                Ok(connected_services(Vec::new())),
+            ]),
+            send_results: VecDeque::from([Err(MainKeyboardError::Transport)]),
+            ..FakeMainKeyboardWire::default()
+        };
+
+        assert_eq!(
+            create_main_keyboard_on_wire(&mut wire).await.unwrap_err(),
+            MainKeyboardError::RollbackFailed
+        );
+    }
+
+    #[test]
+    fn main_keyboard_response_and_connected_service_bounds_fail_closed() {
+        for malformed in [
+            crate::plist!({}),
+            crate::plist!({ "serviceID": 0_u64 }),
+            crate::plist!({ "serviceID": "4097" }),
+            plist::Value::String("not a dictionary".into()),
+        ] {
+            assert_eq!(
+                parse_created_main_keyboard_id(&malformed),
+                Err(MainKeyboardError::MalformedResponse)
+            );
+        }
+
+        let too_many = connected_services(
+            (1..=MAX_CONNECTED_HID_SERVICES + 1)
+                .map(|service_id| hid_surface(service_id as u64, "bounded surface", 1, 6))
+                .collect(),
+        );
+        assert!(parse_hid_surfaces(&too_many).is_err());
+
+        let duplicate = connected_services(vec![
+            hid_surface(42, "one", 1, 6),
+            hid_surface(42, "two", 1, 6),
+        ]);
+        assert!(parse_hid_surfaces(&duplicate).is_err());
+    }
+
+    #[tokio::test]
+    async fn main_keyboard_key_state_reset_and_remove_are_owned_and_idempotent() {
+        let service_id = 0x1_0000_3001;
+        let mut service = MainKeyboardService {
+            service_id,
+            pressed: [0; MAIN_KEYBOARD_USAGE_BITMAP_BYTES],
+            active: true,
+            _ownership: MainKeyboardOwnership,
+        };
+        let mut wire = FakeMainKeyboardWire {
+            replies: VecDeque::from([Ok(connected_services(Vec::new()))]),
+            ..FakeMainKeyboardWire::default()
+        };
+        let letter_a = KeyboardUsage::new(0x04).unwrap();
+        let left_shift = KeyboardUsage::new(0xE1).unwrap();
+
+        replace_main_keyboard_usages_on_wire(
+            &mut wire,
+            &mut service,
+            main_keyboard_usage_bitmap([letter_a, left_shift]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(service.pressed_count(), 2);
+        let send = operation_payload(&wire.sent[0].0, "send");
+        let report = send
+            .get("_0")
+            .and_then(|value| match value {
+                XPCObject::Data(report) => Some(report),
+                _ => None,
+            })
+            .expect("private keyboard report");
+        assert_eq!(report.len(), 39);
+        assert_eq!(report[0], MAIN_KEYBOARD_REPORT_ID);
+        assert_eq!(report[1], 0b0001_0000);
+        assert_eq!(report[29], 0b0000_0010);
+        assert_eq!(send.get("_1"), Some(&XPCObject::UInt64(service_id)));
+
+        reset_main_keyboard_on_wire(&mut wire, &mut service)
+            .await
+            .unwrap();
+        assert_eq!(service.pressed_count(), 0);
+        remove_main_keyboard_on_wire(&mut wire, &mut service)
+            .await
+            .unwrap();
+        assert!(!service.is_active());
+        assert_eq!(wire.sent.len(), 5);
+        assert_eq!(
+            operation_payload(&wire.sent[1].0, "resetGestureState").get("_0"),
+            Some(&XPCObject::UInt64(service_id))
+        );
+        assert_eq!(
+            operation_payload(&wire.sent[3].0, "removeService").get("_0"),
+            Some(&XPCObject::UInt64(service_id))
+        );
+
+        remove_main_keyboard_on_wire(&mut wire, &mut service)
+            .await
+            .unwrap();
+        assert_eq!(wire.sent.len(), 5);
+    }
+
+    #[test]
+    fn main_keyboard_usage_validation_matches_the_system_descriptor() {
+        assert_eq!(KeyboardUsage::new(1).unwrap().raw(), 1);
+        assert_eq!(KeyboardUsage::new(231).unwrap().raw(), 231);
+        assert_eq!(KeyboardUsage::new(0), Err(MainKeyboardError::InvalidUsage));
+        assert_eq!(
+            KeyboardUsage::new(232),
+            Err(MainKeyboardError::InvalidUsage)
+        );
+        assert_eq!(
+            KeyboardUsage::new(u16::MAX),
+            Err(MainKeyboardError::InvalidUsage)
+        );
     }
 }


### PR DESCRIPTION
> This code was written by codex.

I’m developing a feature similar to DeviceHub.app and noticed that the keyboard interaction behaves differently. 

For example, DeviceHub.app doesn’t display an on-screen keyboard when typing, and entering text doesn’t trigger the system’s autocomplete suggestions. 

I discovered that DeviceHub.app uses `mainKeyboardService`, after adding this functionality to Codex, it works properly in my app.